### PR TITLE
The create account session API is failing to surface errors because of a bad variable name

### DIFF
--- a/server/routes/stripe.js
+++ b/server/routes/stripe.js
@@ -175,8 +175,9 @@ router.get('/create-account-session', async (req, res, next) => {
       client_secret: accountSession.client_secret,
       publishable_key: process.env.STRIPE_PUBLISHABLE_KEY,
     });
-  } catch (err) {
-    console.error(err);
+  } catch (error) {
+    console.log('Failed to create an account session')
+    console.error(error);
     res.status(500);
     res.send({error: error.message});
   }


### PR DESCRIPTION
The create account session API fails to surface 500/400's since the error variable is not used consistently.