### PR TITLE
Remove unnecessary remarks around pre-filling

### DIFF
--- a/server/views/signup.pug
+++ b/server/views/signup.pug
@@ -94,7 +94,7 @@ block content
             h4 Prefill account onboarding
             label
               input(type="checkbox" name="prefill" value="prefill") 
-              span Check this if you want to simulate prefilling information into the account before Connect onboarding. Prefilled information will not be collected again in the Connect Onboarding flow. When using prefill as an option, you will be prompted to verify the prefilled details. Use the first and last name you entered here, a date of birth of 01/01/1901, and "0000" as the last 4 digits of the SSN.
+              span Check this if you want to simulate prefilling information into the account before Connect onboarding. Prefilled information will not be collected again in the Connect Onboarding flow.
 
           input.primary(type='submit' value='Create account')
 


### PR DESCRIPTION
These remarks are outdated - this PR removes the now removed "verification" step.