### PR TITLE
Hide the currency row if changing currency is not supported

### DIFF
--- a/server/public/javascripts/createPayments.js
+++ b/server/public/javascripts/createPayments.js
@@ -3,6 +3,7 @@ const paymentFormButton = paymentForm.querySelector('input[type="submit"]');
 const paymentMessageStatus = document.querySelector(
   'div.create-payments-status'
 );
+const currencyRow = document.querySelector('#currency-row');
 
 // Disables the currency selector when not using a successful payment status
 paymentForm
@@ -11,11 +12,9 @@ paymentForm
     event.preventDefault();
     const {value} = event.target;
     if (value.startsWith('card_successful')) {
-      paymentForm.querySelector('select[name="currency"]').style.display =
-        'block';
+      currencyRow.style.display = 'flex';
     } else {
-      paymentForm.querySelector('select[name="currency"]').style.display =
-        'none';
+      currencyRow.style.display = 'none';
     }
   });
 

--- a/server/views/dashboard.pug
+++ b/server/views/dashboard.pug
@@ -33,7 +33,7 @@ block footer
                             option(value="card_uncaptured") Uncaptured
                             option(value="ach_direct_debit") ACH Direct Debit
                             option(value="sepa_debit") SEPA Direct Debit
-                    .row(label='Currency')
+                    .row(label='Currency' id='currency-row')
                         select(name='currency')
                             option(value="" selected) Default
                             option(value="aed") AED


### PR DESCRIPTION
This PR ensures the currency option disappears whenever a payment method is selected that doesn't support multiple currencies. This is a minor improvement to the UI.

https://user-images.githubusercontent.com/95381655/218226899-2bce28e4-3fd6-4380-b8b2-7b561a535695.mov
