### PR TITLE
Add check for href attribute when persisting URL query params

### DIFF
--- a/server/public/javascripts/persistQueryParams.js
+++ b/server/public/javascripts/persistQueryParams.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('a').forEach((el) => {
     const href = el.getAttribute('href');
     // Only if it's a relative path
-    if (href.startsWith('/')) {
+    if (href && href.startsWith('/')) {
       el.setAttribute('href', href + window.location.search);
     }
   });


### PR DESCRIPTION
Add check for href attribute when persisting URL query params. Without this, this causes the for loop to throw an error when an <a> tag does not have a href attribute.