### PR TITLE
Add alert about demo site to reservations page

### DIFF
--- a/server/public/stylesheets/furever.css
+++ b/server/public/stylesheets/furever.css
@@ -108,7 +108,7 @@ a.arrow {
   align-items: center;
   width: 100%;
   max-width: 1200px;
-  z-index: 1;
+  z-index: 3;
 }
 
 /* Nav logo */
@@ -1324,7 +1324,6 @@ section.reservations h2 {
   padding: 0.5rem;
   overflow-x: hidden;
   transition: all 0.2s;
-  cursor: pointer;
   border-left: 2px solid #228403;
   z-index: 2;
   position: relative;

--- a/server/views/reservations.pug
+++ b/server/views/reservations.pug
@@ -1,21 +1,25 @@
 extends layout
 
 block content
+    script.
+        function alertDemoSite() {
+            alert("Woof woof, this is a demo site! This functionality in this website is minimal as this is only a demo, but you can use the payments and payouts tabs, as well as the account page to test Connect Embedded components.")
+        }
     section.reservations 
         h2 Upcoming appointments
 
         .calendar-header 
             .calendar-date-selector 
-                button ‹
+                button(onclick="alertDemoSite()") ‹
                 div Dec 5, 2022
                 div Today 
-                button ›
+                button(onclick="alertDemoSite()") ›
 
             .calendar-settings 
                 .calendar-settings-view 
-                    div Day 
-                    div Week
-                button ﹢ New appointment
+                    div(onclick="alertDemoSite()") Day 
+                    div(onclick="alertDemoSite()") Week
+                button(onclick="alertDemoSite()") ﹢ New appointment
 
         .calendar
             table


### PR DESCRIPTION
We don't want to confuse users about the functionality of the reservations page as it is just a placeholder.