### PR TITLE
Link to API reference site for payment intents and payouts

### DIFF
--- a/server/views/payments.pug
+++ b/server/views/payments.pug
@@ -16,7 +16,7 @@ block footer
                 h4 Create a test payment
                 i(class="fa fa-chevron-up")
             .description
-                p Simulate a grooming session by using a testmode payment method to #[a(href="https://stripe.com/docs/payments/payment-intents" target="_blank") create a payment intent].
+                p Simulate a grooming session by using a testmode payment method to #[a(href="https://stripe.com/docs/api/payment_intents" target="_blank") create a payment intent].
             form.right(id='create-payments' autocomplete='off')
                 fieldset
                     .row(label='Count')

--- a/server/views/payouts.pug
+++ b/server/views/payouts.pug
@@ -16,7 +16,7 @@ block footer
                 h4 Create a test payout
                 i(class="fa fa-chevron-up")
             .description
-                p Simulate a #[a(href="https://stripe.com/docs/payments/payment-intents" target="_blank") payout] from your Stripe balance to your bank account.
+                p Simulate a #[a(href="https://stripe.com/docs/api/payouts" target="_blank") payout] from your Stripe balance to your bank account.
             form.right(id='create-payouts' autocomplete='off')
                 input(type='submit' name="immediate_balance" value='Create test payout' class='primary-action')
                 div.create-payout-status


### PR DESCRIPTION
We were linking out to a payment intent doc site for payouts, so this PR fixes that. I also made both links consistent (to the payments/payouts API reference, since this site is for developers)