### PR TITLE
Fix generation of calendar dates

### DIFF
--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -139,18 +139,20 @@ router.get('/reservations', stripeAccountRequired, async (req, res) => {
   const options = {month: 'short', day: 'numeric', year: 'numeric'};
   const formattedDate = currentDate.toLocaleDateString('en-US', options);
 
-  const daysOfWeek = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-  const currentDayOfWeekIndex = (currentDate.getDay() - 1 + 7) % 7;
+  const daysOfWeek = ['Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat', 'Sun'];
   const datesArray = [];
-
+  const currentDayOfWeekIndex = (currentDate.getDay() - 1 + 7) % 7;
+  // Get the first day of the week (Monday) for the given date
+  const firstDayOfWeek = currentDate;
+  firstDayOfWeek.setDate(firstDayOfWeek.getDate() - currentDayOfWeekIndex);
+  // Add the dates for the current week to the result array
   for (let i = 0; i < 7; i++) {
-    const date = new Date();
-    date.setDate(currentDate.getDate() + i);
-    const dayOfWeekIndex = (currentDayOfWeekIndex + i) % 7;
-    const dayOfWeek = daysOfWeek[dayOfWeekIndex];
-    const dayOfMonth = date.getDate();
-    const dateString = `${dayOfWeek}, ${dayOfMonth}`;
-    datesArray.push(dateString);
+    datesArray.push(
+      `${
+        daysOfWeek[(firstDayOfWeek.getDay() - 1 + 7) % 7]
+      } ${firstDayOfWeek.getDate()}`
+    );
+    firstDayOfWeek.setDate(firstDayOfWeek.getDate() + 1);
   }
 
   res.render('reservations', {

--- a/server/views/reservations.pug
+++ b/server/views/reservations.pug
@@ -33,7 +33,7 @@ block content
                     each time in [0,8,0,9,0,10,0,11,0,12,0,13,0,14,0,15,0,16,0,17,0,18,0]
                         tr
                             each day, index in reservations
-                                td(class={'firstcol': index === 0, 'past': index > 0 && index - 1 <= currentDayOfWeekIndex}) #{time !== 0 && index === 0 ? `${time}:00` : ''}
+                                td(class={'firstcol': index === 0, 'past': index > 0 && index - 1 < currentDayOfWeekIndex}) #{time !== 0 && index === 0 ? `${time}:00` : ''}
                                     if time in day
                                         .event(style=`height: ${(day[time].end - time) * 200}%`)
                                             p #{day[time].title}


### PR DESCRIPTION
Before:
<img width="1263" alt="Screenshot 2023-04-26 at 9 40 33 AM" src="https://user-images.githubusercontent.com/104949269/234644682-a08f5a16-e55c-4fac-8ced-47cc3f6bf65d.png">

After:
<img width="925" alt="Screenshot 2023-04-26 at 9 40 19 AM" src="https://user-images.githubusercontent.com/104949269/234644672-2f72ad17-384e-4a0c-bc22-e0190221c96e.png">
