### PR TITLE
Allow visiting the 'signup' page even after onboarding

### DIFF
--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -19,10 +19,8 @@ router.get('/signup', (req, res) => {
   if (req.user) {
     if (!req.user.stripeAccountId) {
       step = 'profile'; // Mising onboarding to platform + Stripe
-    } else if (!req.stripeAccount?.details_submitted) {
-      step = 'onboarding'; // Missing onboarding to Stripe
     } else {
-      return res.redirect('/reservations'); // Created account + onboarded to Stripe
+      step = 'onboarding'; // Created account. They may or may not be onboarded, but this page will display the right UI for either case
     }
   }
   res.render('signup', {step: step});


### PR DESCRIPTION
This PR changes the server side logic so that you can visit the `signup` page even after onboarding. This can be useful for demoing/testing the `stripe-connect-account-onboarding` component.

Note we still redirect to /dashboard after onboarding on the client side.