### PR TITLE
The landing page for FurEver after signing in should be /reservations, not /signup

### DIFF
--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -81,7 +81,7 @@ router.get('/login', (req, res) => {
 router.post(
   '/login',
   passport.authenticate('salon-login', {
-    successRedirect: '/signup',
+    successRedirect: '/reservations', // Redirect to our landing page
     failureRedirect: '/login',
   })
 );


### PR DESCRIPTION
I noticed we were redirecting to /signup (often causing a double redirect), however with https://github.com/stripe/stripe-connect-furever/pull/48, the user is redirected to /signup even after they have onboarded. I am changing this to /dashboard, since that will show a CTA to onboard if the user isn't onboarded yet.