### PR TITLE
Add minimum node version for mongodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "type": "module",
   "source": "client/index.html",
+  "engines": {
+    "node": ">=14.20.1"
+  },
   "scripts": {
     "build": "parcel build client/index.html",
     "clean": "rimraf dist",


### PR DESCRIPTION
Received an error: `error mongodb@5.4.0: The engine "node" is incompatible with this module. Expected version ">=14.20.1". Got "14.17.0"`