### PR TITLE
Adds express and standard possibilities via onboarding link

### DIFF
--- a/client/components/CompleteProfile.tsx
+++ b/client/components/CompleteProfile.tsx
@@ -365,6 +365,12 @@ const CompleteProfile = () => {
                 <option value="dashboard_soll">
                   Dashboard access + Stripe owns loss liability
                 </option>
+                <option value="default_standard">
+                  Standard account
+                </option>
+                <option value="default_express">
+                  Express account
+                </option>
               </SelectInput>
             </FormBlock>
           </FormControl>

--- a/client/components/OnboardingNotice.tsx
+++ b/client/components/OnboardingNotice.tsx
@@ -23,7 +23,7 @@ export const OnboardingNotice = () => {
     >
       <Typography color="white">
         You need to complete onboarding.{' '}
-        <Link component={RouterLink} to="/onboard">
+        <Link component={RouterLink} to="/onboarding">
           <Typography
             component="span"
             color="white"

--- a/client/routes/Onboarding.tsx
+++ b/client/routes/Onboarding.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useMutation} from 'react-query';
 import {useNavigate} from 'react-router-dom';
+import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import {ConnectAccountOnboarding} from '@stripe/react-connect-js';
@@ -13,6 +14,7 @@ import {
 import {useSession} from '../hooks/SessionProvider';
 import {Container} from '../components/Container';
 import StripeConnectDebugUtils from '../components/StripeConnectDebugUtils';
+import Stripe from 'stripe';
 
 const useOnboarded = () => {
   const {refetch} = useSession();
@@ -31,9 +33,19 @@ const useOnboarded = () => {
   });
 };
 
+const goToOnboard = async (stripeAccount: Stripe.Account | null | undefined) => {
+  const response = await fetch('/stripe/create-account-onboarding-link', {
+    method: 'POST',
+    body: JSON.stringify(stripeAccount)
+  });
+  const {url} = await response.json();
+  location.href = url;
+}
+
 const Onboarding = () => {
   const {mutate, error} = useOnboarded();
-
+  const {stripeAccount} = useSession();
+  const isHostedOnboarding = stripeAccount?.type === 'express' || stripeAccount?.type === 'standard';
   return (
     <>
       <Container sx={{alignItems: 'center', gap: 4, marginBottom: 2}}>
@@ -45,6 +57,18 @@ const Onboarding = () => {
         >
           Onboard to Stripe
         </Typography>
+        {isHostedOnboarding && <Button
+            fullWidth
+            variant="contained"
+            onClick={() => {
+              goToOnboard(stripeAccount);
+            }}
+            sx={{
+              fontWeight: 700,
+            }}
+          >
+            Onboard to Stripe
+        </Button>}
         <EmbeddedContainer>
           <EnableEmbeddedCheckbox label="Enable embedded onboarding" />
           <EmbeddedComponentContainer>


### PR DESCRIPTION
Currently it's not possible to use this demo for express or standard accounts. I wanted to fix this by adding:
- Express and standard as part of the `?dev=true` options
- Adding a button in the onboarding page to allow for account link onboarding, as this is the only supported experience for this type of accounts

Happy to make any changes if this helps