### PR TITLE
Don't use `npx` in FurEver

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "yarn clean && yarn typescript && yarn watch",
     "server": "node dist/server/server.js",
     "start": "yarn clean && yarn build && yarn server",
-    "typescript": "npx tsc",
+    "typescript": "yarn tsc",
     "watch": "concurrently --kill-others \"parcel watch client/index.html\" \"yarn server\""
   },
   "dependencies": {


### PR DESCRIPTION
We don't need to use `npx` - switch to using `yarn`.