### PR TITLE
Create dashboard accounts where stripe owns loss liability, not where the platform owns loss liability

### DIFF
--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -182,7 +182,7 @@ function getAccountParams(accountConfiguration: string) {
       capabilities = undefined;
       controller = {
         application: {
-          loss_liable: true, // Platform owns loss liability
+          loss_liable: false, // Stripe owns loss liability
           onboarding_owner: false, // Stripe is the onboarding owner
           pricing_controls: true, // The platform is the pricing owner
         },


### PR DESCRIPTION
Spotted this bug thanks to @kalyan-stripe 