### PR TITLE
Update OnboardingNotice.tsx

### DIFF
--- a/client/components/OnboardingNotice.tsx
+++ b/client/components/OnboardingNotice.tsx
@@ -25,7 +25,7 @@ export const OnboardingNotice = () => {
     >
       <Typography color="white">
         You need to complete onboarding.{' '}
-        <Link component={RouterLink} to="/onboard">
+        <Link component={RouterLink} to="/onboarding">
           <Typography
             component="span"
             color="white"


### PR DESCRIPTION
Noticed the link was linking to furever.com/onboard but it should be /onboarding instead.
onboard 404s <img width="669" alt="image" src="https://github.com/stripe/stripe-connect-furever/assets/124314569/8456eca7-fb84-49e0-8d43-c3f34e8bb3e2">

onboarding is right link:
<img width="756" alt="image" src="https://github.com/stripe/stripe-connect-furever/assets/124314569/c93e4aba-ec85-4e51-ad4a-b185d5f6a5b0">

