### PR TITLE
Surface error when retrieving Stripe account to UI

### DIFF
--- a/server/routes/middleware.ts
+++ b/server/routes/middleware.ts
@@ -31,14 +31,10 @@ export function stripeAccountRequired(
 }
 
 export async function retrieveStripeAccount(accountId: string) {
-  try {
-    const account = await stripe.accounts.retrieve(accountId);
-    if (account) {
-      return account;
-    } else {
-      return null;
-    }
-  } catch (err) {
-    return null;
+  const account = await stripe.accounts.retrieve(accountId);
+  if (account) {
+    return account;
+  } else {
+    throw new Error(`Couldn't retrieve Stripe account: ${accountId}`);
   }
 }


### PR DESCRIPTION
Let the server endpoints handle the error

<img width="885" alt="Screenshot 2023-06-13 at 10 30 51 AM" src="https://github.com/stripe/stripe-connect-furever-demo/assets/104949269/e16ec861-a089-4e8a-a05e-e9f3fa49e804">
