### PR TITLE
Persist query params when navigating

### DIFF
--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -20,12 +20,14 @@ import {OnboardingNotice} from './OnboardingNotice';
 import RouterLink from './RouterLink';
 
 const useLogout = () => {
+  const {search} = useLocation();
+
   return useMutation<void, Error>('logout', async () => {
     const response = await fetch('/api/logout', {
       method: 'POST',
     });
     if (response.ok) {
-      window.location.replace('/');
+      window.location.replace(`/${search}`);
     }
   });
 };

--- a/client/routes/BankAccountForm.tsx
+++ b/client/routes/BankAccountForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useNavigate} from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import {useMutation} from 'react-query';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -21,12 +21,13 @@ const useCreateBankAccount = () => {
 };
 
 const BankAccountForm = () => {
+  const {search} = useLocation();
   const navigate = useNavigate();
   const {status, mutate, isLoading, error} = useCreateBankAccount();
 
   React.useEffect(() => {
     if (status === 'success') {
-      navigate('/profile');
+      navigate(`/profile${search}`);
       navigate(0);
     }
   }, [status]);

--- a/client/routes/Onboarding.tsx
+++ b/client/routes/Onboarding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useMutation} from 'react-query';
-import {useNavigate} from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import {ConnectAccountOnboarding} from '@stripe/react-connect-js';
@@ -19,13 +19,14 @@ const useOnboarded = () => {
   const navigate = useNavigate();
 
   return useMutation<void, Error>('login', async () => {
+    const {search} = useLocation();
     const response = await fetch('/stripe/onboarded', {
       method: 'GET',
     });
     const {onboarded} = await response.json();
     if (onboarded) {
       refetch();
-      navigate('/reservations');
+      navigate(`/reservations${search}`);
     } else {
       navigate(0);
     }
@@ -33,6 +34,7 @@ const useOnboarded = () => {
 };
 
 const Onboarding = () => {
+  const {search} = useLocation();
   const {mutate, error} = useOnboarded();
   const {stripeAccount} = useSession();
   const navigate = useNavigate();
@@ -56,7 +58,7 @@ const Onboarding = () => {
                   'Onboarding exited! We redirect the user to the next page...'
                 );
                 if (stripeAccount?.type === 'custom') {
-                  navigate('/bankaccountform');
+                  navigate(`/bankaccountform${search}`);
                 }
                 mutate();
               }}

--- a/client/routes/RouteHandlers.tsx
+++ b/client/routes/RouteHandlers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Navigate} from 'react-router-dom';
+import {Navigate, useLocation} from 'react-router-dom';
 import {useSession} from '../hooks/SessionProvider';
 
 export const UnauthenticatedRoute = ({
@@ -7,6 +7,7 @@ export const UnauthenticatedRoute = ({
 }: {
   children: React.ReactNode;
 }): JSX.Element => {
+  const {search} = useLocation();
   const {user, stripeAccount} = useSession();
   if (!user) {
     return <>{children}</>;
@@ -14,16 +15,16 @@ export const UnauthenticatedRoute = ({
 
   // If no Stripe account, user needs to complete their profile
   if (!stripeAccount) {
-    return <Navigate to="/signup" replace />;
+    return <Navigate to={`/signup${search}`} replace />;
   }
 
   // If not fully onboarded, redirect to onboarding page
   if (!stripeAccount.details_submitted) {
-    return <Navigate to="/onboarding" replace />;
+    return <Navigate to={`/onboarding${search}`} replace />;
   }
 
   // If the user is fully onboarded, redirect to the reservations page
-  return <Navigate to="/reservations" replace />;
+  return <Navigate to={`/reservations${search}`} replace />;
 };
 
 export const OnboardingRoute = ({
@@ -31,6 +32,7 @@ export const OnboardingRoute = ({
 }: {
   children: React.ReactNode;
 }): JSX.Element => {
+  const {search} = useLocation();
   const {user, stripeAccount} = useSession();
   if (!user || !stripeAccount) {
     return <>{children}</>;
@@ -38,11 +40,11 @@ export const OnboardingRoute = ({
 
   // If not fully onboarded, redirect to onboarding page
   if (!stripeAccount.details_submitted) {
-    return <Navigate to="/onboarding" replace />;
+    return <Navigate to={`/onboarding${search}`} replace />;
   }
 
   // If the user is fully onboarded, redirect to the reservations page
-  return <Navigate to="/reservations" replace />;
+  return <Navigate to={`/reservations${search}`} replace />;
 };
 
 export const AuthenticatedAndOnboardedRoute = ({
@@ -50,12 +52,13 @@ export const AuthenticatedAndOnboardedRoute = ({
 }: {
   children: (user: Express.User) => JSX.Element;
 }): JSX.Element => {
+  const {search} = useLocation();
   const {user, stripeAccount} = useSession();
   if (!user) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to={`/login${search}`} replace />;
   }
   if (!stripeAccount) {
-    return <Navigate to="/signup" replace />;
+    return <Navigate to={`/signup${search}`} replace />;
   }
   return <>{children(user)}</>;
 };
@@ -65,9 +68,10 @@ export const CustomGatedRoute = ({
 }: {
   children: React.ReactNode;
 }): JSX.Element => {
+  const {search} = useLocation();
   const {stripeAccount} = useSession();
   if (stripeAccount?.type !== 'custom') {
-    return <Navigate to="/reservations" replace />;
+    return <Navigate to={`/reservations${search}`} replace />;
   }
   return <>{children}</>;
 };


### PR DESCRIPTION
This PR fixes some (_hopefully_ all) of the page navigations so that all query parameters are persisted during navigation.

This will remove some of the friction of testing UA2 accounts. Currently, the app drops some query parameters that are necessary for UA2 embedded onboarding to function properly (namely, `enable_standard_account_access=true`), which have to be manually re-added to the URL after navigating.