### PR TITLE
Specify correct theming options in FurEver

### DIFF
--- a/client/hooks/ConnectJsWrapper.tsx
+++ b/client/hooks/ConnectJsWrapper.tsx
@@ -62,17 +62,17 @@ const useInitStripeConnect = (enabled: boolean) => {
         publishableKey,
         refreshClientSecret,
         appearance: {
+          // FurEver specifies a subset of the available options in ConnectJS
           colorPrimary: theme.palette.primary.main,
           colorText: theme.palette.text.primary,
+          colorBackground: theme.palette.background.default,
           colorSecondaryText: theme.palette.text.secondary,
           colorSecondaryLinkText: theme.palette.secondary.main,
           colorBorder: theme.palette.border.main,
           colorFormHighlight: theme.palette.primary.main,
-          colorFeedbackSuccess: theme.palette.success.main,
-          colorFeedbackCritical: theme.palette.error.main,
+          colorFeedbackDanger: theme.palette.error.main,
           colorSecondaryButtonBackground: theme.palette.neutral100.main,
           colorSecondaryButtonBorder: theme.palette.border.main,
-          colorOffsetBackground: theme.palette.background.default,
         } as Record<string, string>, // TODO: Remove casting once we've shipped theming options to beta
         uiConfig: {
           overlay: 'dialog',


### PR DESCRIPTION
Right now FurEver does not specify `colorBackground` and a few other tokens. This PR revises how these tokens are specified to fix FurEver to fix dark mode:

<img width="1137" alt="image" src="https://github.com/stripe/stripe-connect-furever-demo/assets/95381655/d7abb502-b6af-4101-8e0c-d3ab3431842f">
