### PR TITLE
Allow dynamic currencies for all test payment methods that support them

### DIFF
--- a/client/routes/Payments.tsx
+++ b/client/routes/Payments.tsx
@@ -19,6 +19,7 @@ import {
 import {Container} from '../components/Container';
 import StripeConnectDebugUtils from '../components/StripeConnectDebugUtils';
 import { ConnectNotificationBanner } from '../components/internal/ConnectJsPrivateComponents';
+import { staticCurrencyPaymentMethods } from '../../shared/staticCurrencies';
 
 type FormValues = {
   count: string;
@@ -198,7 +199,7 @@ const Payments = () => {
               <option value="ach_direct_debit">ACH Direct Debit</option>
               <option value="sepa_debit">SEPA Direct Debit</option>
             </SelectInput>
-            {formValues.status.startsWith('card_successful') && (
+            {!staticCurrencyPaymentMethods.includes(formValues.status) && (
               <>
                 <Divider />
                 <SelectInput

--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -7,6 +7,7 @@ import {
 } from './middleware.js';
 import { stripeSdk } from './stripeSdk.js';
 import stripe from 'stripe';
+import { staticCurrencyPaymentMethods } from '../../shared/staticCurrencies.js';
 
 dotenv.config({path: './.env'});
 
@@ -511,7 +512,7 @@ app.post('/create-payments', stripeAccountRequired, async (req, res) => {
               ? Math.round(inputAmount) * 100
               : getRandomInt(1000, 10000), // Use a random amount if input is not provided,
             currency:
-              status.startsWith('card_successful') && currency
+              !staticCurrencyPaymentMethods.includes(status) && currency
                 ? currency
                 : account.default_currency,
             name,

--- a/shared/staticCurrencies.ts
+++ b/shared/staticCurrencies.ts
@@ -1,0 +1,2 @@
+// The following test payment methods don't support dynamic currencies
+export const staticCurrencyPaymentMethods = ['sepa_debit', 'ach_direct_debit'];


### PR DESCRIPTION
With these updates, you can create test disputes or uncaptured payments with any currency.

![image](https://github.com/stripe/stripe-connect-furever-demo/assets/95381655/a1360505-349f-4d41-b4a5-4f8fb8a2d78f)
