### PR TITLE
Fix navbar menu links in FurEver

### DIFF
--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -166,13 +166,13 @@ export const NavBar = () => {
           {user &&
             stripeAccount &&
             settings.map(({name, href}) => (
-              <MenuItem key={name} onClick={handleCloseNavMenu}>
-                <Link component={RouterLink} to={href} underline="none">
+              <Link component={RouterLink} to={href} underline="none">
+                <MenuItem key={name} onClick={handleCloseNavMenu}>
                   <Typography textAlign="center" variant="body2">
                     {name}
                   </Typography>
-                </Link>
-              </MenuItem>
+                </MenuItem>
+              </Link>
             ))}
           {routes.map(({name, href}) => (
             <MenuItem


### PR DESCRIPTION
Before:
- Clicking on the menu item (i.e. not directly on the "Profile" text) does not browse to the right page

https://github.com/stripe/stripe-connect-furever-demo/assets/95381655/faf5c929-8de1-45a0-8e9c-4b28f09fd64c

After:
- Clicking anywhere on the menu item does browse to the right page
https://github.com/stripe/stripe-connect-furever-demo/assets/95381655/5042fe87-826c-4f23-9766-c4260cc7496f
