### PR TITLE
Fix refresh issues for custom onboarding

### DIFF
--- a/client/routes/BankAccountForm.tsx
+++ b/client/routes/BankAccountForm.tsx
@@ -68,6 +68,7 @@ export const BankAccountForm = () => {
 
   React.useEffect(() => {
     if (status === 'success') {
+      navigate(0);
       navigate(`/profile${search}`);
     }
   }, [status]);

--- a/client/routes/Onboarding.tsx
+++ b/client/routes/Onboarding.tsx
@@ -15,7 +15,7 @@ import {StripeConnectDebugUtils} from '../components/StripeConnectDebugUtils';
 import {ConnectAccountOnboarding} from '../components/internal/ConnectJsPrivateComponents';
 
 const useOnboarded = () => {
-  const {refetch} = useSession();
+  const {refetch, stripeAccount} = useSession();
   const navigate = useNavigate();
   const {search} = useLocation();
 
@@ -27,7 +27,7 @@ const useOnboarded = () => {
     if (onboarded) {
       refetch();
       navigate(`/reservations${search}`);
-    } else {
+    } else if (stripeAccount?.type !== 'custom') {
       navigate(0);
     }
   });


### PR DESCRIPTION
This removes the refresh for custom accounts after onboarding page is complete, and performs a refresh after submitting bank details 