### PR TITLE
Inject a customized ToS and PrivacyPolicy to the Onboarding component

### DIFF
--- a/client/components/internal/ConnectJsPrivateComponents.tsx
+++ b/client/components/internal/ConnectJsPrivateComponents.tsx
@@ -1,5 +1,9 @@
 import {ConnectElementTagName} from '@stripe/connect-js';
-import {useAttachEvent, useCreateComponent} from '@stripe/react-connect-js';
+import {
+  useAttachAttribute,
+  useAttachEvent,
+  useCreateComponent,
+} from '@stripe/react-connect-js';
 import React from 'react';
 
 // Not yet shipped connect components. These are not publicly accessible.
@@ -29,14 +33,20 @@ export const ConnectAccountManagement = (): JSX.Element => {
 
 export const ConnectAccountOnboarding = ({
   onOnboardingExited,
+  privacyPolicyUrl,
+  tosUrl,
 }: {
   onOnboardingExited: () => void;
+  privacyPolicyUrl?: string;
+  tosUrl?: string;
 }): JSX.Element | null => {
   const {wrapper, component: onboarding} = useCreateComponent(
     'stripe-connect-account-onboarding' as any
   );
 
   useAttachEvent(onboarding, 'onboardingexited' as any, onOnboardingExited); // Assuming an 'onboardingexited' event
+  useAttachAttribute(onboarding, 'tos-url', tosUrl);
+  useAttachAttribute(onboarding, 'privacy-policy-url', privacyPolicyUrl);
 
   return wrapper;
 };

--- a/client/routes/Onboarding.tsx
+++ b/client/routes/Onboarding.tsx
@@ -54,6 +54,8 @@ export const Onboarding = () => {
           <EnableEmbeddedCheckbox label="Enable embedded onboarding" />
           <EmbeddedComponentContainer>
             <ConnectAccountOnboarding
+              tosUrl="https://stripe.com/legal?utm_campaign=woof"
+              privacyPolicyUrl="https://stripe.com/privacy?utm_campaign=woof"
               onOnboardingExited={() => {
                 console.log(
                   'Onboarding exited! We redirect the user to the next page...'


### PR DESCRIPTION
In order to demonstrate the ability to customize the ToS and PrivacyPolicy within Embedded Onboarding I've added a `?utm_campaign=woof` suffix to the existing terms/privacy policy URLs that are currently used in furever.dev so that others test out the experience.

#### ToS

<img width="1454" alt="Screenshot 2023-08-29 at 10 24 02" src="https://github.com/stripe/stripe-connect-furever-demo/assets/101747057/9ce2779a-5e1b-4b75-bf68-3ba095446358">

#### Privacy Policy

<img width="1454" alt="Screenshot 2023-08-29 at 10 23 57" src="https://github.com/stripe/stripe-connect-furever-demo/assets/101747057/fe46b473-518f-4c17-80be-5f7b271a4a30">
