### PR TITLE
Updates onboarding to use separate full & recipient ToS URLs

### DIFF
--- a/client/components/internal/ConnectJsPrivateComponents.tsx
+++ b/client/components/internal/ConnectJsPrivateComponents.tsx
@@ -34,19 +34,30 @@ export const ConnectAccountManagement = (): JSX.Element => {
 export const ConnectAccountOnboarding = ({
   onOnboardingExited,
   privacyPolicyUrl,
-  tosUrl,
+  fullTermsOfServiceUrl,
+  recipientTermsOfServiceUrl,
 }: {
   onOnboardingExited: () => void;
   privacyPolicyUrl?: string;
-  tosUrl?: string;
+  fullTermsOfServiceUrl?: string;
+  recipientTermsOfServiceUrl?: string;
 }): JSX.Element | null => {
   const {wrapper, component: onboarding} = useCreateComponent(
     'stripe-connect-account-onboarding' as any
   );
 
   useAttachEvent(onboarding, 'onboardingexited' as any, onOnboardingExited); // Assuming an 'onboardingexited' event
-  useAttachAttribute(onboarding, 'tos-url', tosUrl);
   useAttachAttribute(onboarding, 'privacy-policy-url', privacyPolicyUrl);
+  useAttachAttribute(
+    onboarding,
+    'full-terms-of-service-url',
+    fullTermsOfServiceUrl
+  );
+  useAttachAttribute(
+    onboarding,
+    'recipient-terms-of-service-url',
+    recipientTermsOfServiceUrl
+  );
 
   return wrapper;
 };

--- a/client/routes/Onboarding.tsx
+++ b/client/routes/Onboarding.tsx
@@ -54,8 +54,9 @@ export const Onboarding = () => {
           <EnableEmbeddedCheckbox label="Enable embedded onboarding" />
           <EmbeddedComponentContainer>
             <ConnectAccountOnboarding
-              tosUrl="https://stripe.com/legal?utm_campaign=woof"
               privacyPolicyUrl="https://stripe.com/privacy?utm_campaign=woof"
+              fullTermsOfServiceUrl="https://stripe.com/legal/connect-account?utm_campaign=woof"
+              recipientTermsOfServiceUrl="https://stripe.com/legal/connect-account/recipient?utm_campaign=woof"
               onOnboardingExited={() => {
                 console.log(
                   'Onboarding exited! We redirect the user to the next page...'


### PR DESCRIPTION
In https://github.com/stripe/stripe-connect-furever-demo/pull/92 I introduced the customized `tosUrl` injection for onboarding.

Since then we've separated the `tos-url` attribute into `full-terms-of-service-url` and `recipient-terms-of-service-url` so updating to use the new attributes.