### PR TITLE
Pass manual payment_method_types when creating card-only PaymentIntents

### DIFF
--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -547,6 +547,7 @@ app.post('/create-payments', stripeAccountRequired, async (req, res) => {
                 amount: metadata.amount,
                 currency: metadata.currency,
                 payment_method: getPaymentMethod(status),
+                payment_method_types: ['card'],
                 description,
                 customer: metadata.customerId,
                 statement_descriptor: process.env.APP_NAME,


### PR DESCRIPTION
Fixes an issue due to a backwards-incompatible change in the latest Stripe API version ([more info](https://stripe.com/docs/upgrades/manage-payment-methods)). This was causing card-based PaymentIntents to fail because of Furever's integration shape (immediate manual confirmation with a `payment_method` param). The solution here is to simply pass `payment_method_types: ["card"]` since these are all card-only payments anyhow.

I tested card and non-card payments and also confirmed that Checkout sessions were still working.