### PR TITLE
Use the beta SDK for the payment_method_settings component

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.11.1",
-    "stripe": "15.4.0-beta.1",
+    "stripe": "15.5.0-beta.1",
     "typescript": "^4.5.5"
   },
   "devDependencies": {

--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -452,6 +452,9 @@ app.post('/account_session', stripeAccountRequired, async (req, res) => {
             cardholder_management: true,
           },
         },
+        payment_method_settings: {
+          enabled: true,
+        },
         financial_account: {
           enabled: true,
           features: {
@@ -472,16 +475,9 @@ app.post('/account_session', stripeAccountRequired, async (req, res) => {
         },
       };
 
-    // TODO: Move up once payment_method_settings is in the beta SDK
-    const accountSessionComponentsParamsAsAny =
-      accountSessionComponentsParams as any;
-    accountSessionComponentsParamsAsAny.payment_method_settings = {
-      enabled: true,
-    };
-
     const accountSession = await stripe.accountSessions.create({
       account: getStripeAccountId(req),
-      components: accountSessionComponentsParamsAsAny,
+      components: accountSessionComponentsParams,
     });
     res.json({
       client_secret: accountSession.client_secret,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3339,10 +3339,10 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-stripe@15.4.0-beta.1:
-  version "15.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-15.4.0-beta.1.tgz#244856c24c6af5bff5998530b765d407d817b8fc"
-  integrity sha512-PGcx1oJgXpz1S/e9k2HfGf6NIkE3GSZuw3Fc3LUjXXP21eYOrrNejJKktuZPn0cWpzMyYfTtod/MbtiHHYzy6A==
+stripe@15.5.0-beta.1:
+  version "15.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-15.5.0-beta.1.tgz#24fcaab65011288c8fd2ffc4823b036e3e77fcf6"
+  integrity sha512-aLz7B+mrSIxmSulV+Skkd6hWB0XedSd0CSzhQqwyQov++6xZEP0/j5dAQYJA9ZWJaKpr0rOffY4DwxKQlk1tRQ==
   dependencies:
     "@types/node" ">=8.1.0"
     qs "^6.11.0"


### PR DESCRIPTION
This PR pulls in the latest `stripe` package version 15.5.0-beta.1 in order to support the `payment_method_settings` component. It also removes the TS hack that was necessary to include the component before this.