### PR TITLE
Specify a value for external_account_collection

### DIFF
--- a/client/components/CompleteProfile.tsx
+++ b/client/components/CompleteProfile.tsx
@@ -25,7 +25,7 @@ type FormValues = {
   salonName: string;
   salonLicense: string;
   salonSpecialty: string;
-  accountConfiguration: string;
+  accountConfig: string;
 };
 
 const FormControl = ({children}: {children: React.ReactNode}) => (
@@ -83,7 +83,7 @@ export const CompleteProfile = () => {
     salonName: '',
     salonLicense: 'LINC123',
     salonSpecialty: 'dogs',
-    accountConfiguration: 'no_dashboard_soll',
+    accountConfig: 'no_dashboard_soll',
   });
   const [searchParams] = useSearchParams();
   const {mutate, isLoading, error} = useCreateStripeAccount();
@@ -348,12 +348,12 @@ export const CompleteProfile = () => {
           <FormBlock>
             <SelectInput
               type="select"
-              name="accountConfiguration"
-              value={formValues.accountConfiguration}
+              name="accountConfig"
+              value={formValues.accountConfig}
               onChange={(event) =>
                 setFormValues((prev) => ({
                   ...prev,
-                  accountConfiguration: event.target.value,
+                  accountConfig: event.target.value,
                 }))
               }
             >
@@ -364,7 +364,7 @@ export const CompleteProfile = () => {
               </option>
               <option value="no_dashboard_poll">
                 Connected account without Stripe dashboard access + FurEver is
-                liable for paying back negative balances + FurEver collects fees
+                liable for paying back negative balances + Stripe collects fees
                 from FurEver
               </option>
               <option value="dashboard_soll">

--- a/client/components/CompleteProfile.tsx
+++ b/client/components/CompleteProfile.tsx
@@ -364,7 +364,7 @@ export const CompleteProfile = () => {
               </option>
               <option value="no_dashboard_poll">
                 Connected account without Stripe dashboard access + FurEver is
-                liable for paying back negative balances + Stripe collects fees
+                liable for paying back negative balances + FurEver collects fees
                 from FurEver
               </option>
               <option value="dashboard_soll">

--- a/client/routes/Onboarding.tsx
+++ b/client/routes/Onboarding.tsx
@@ -15,7 +15,7 @@ import {StripeConnectDebugUtils} from '../components/StripeConnectDebugUtils';
 import {ConnectAccountOnboarding} from '@stripe/react-connect-js';
 
 const useOnboarded = () => {
-  const {refetch, stripeAccount} = useSession();
+  const {refetch, user} = useSession();
   const navigate = useNavigate();
   const {search} = useLocation();
 
@@ -27,7 +27,7 @@ const useOnboarded = () => {
     if (onboarded) {
       refetch();
       navigate(`/reservations${search}`);
-    } else if (stripeAccount?.type !== 'custom') {
+    } else if (user?.accountConfig === 'no_dashboard_poll') {
       navigate(0);
     }
   });
@@ -36,7 +36,7 @@ const useOnboarded = () => {
 export const Onboarding = () => {
   const {search} = useLocation();
   const {mutate, error} = useOnboarded();
-  const {stripeAccount} = useSession();
+  const {user} = useSession();
   const navigate = useNavigate();
 
   return (
@@ -62,7 +62,7 @@ export const Onboarding = () => {
                   'Onboarding exited! We redirect the user to the next page...'
                 );
                 mutate();
-                if (stripeAccount?.type === 'custom') {
+                if (user?.accountConfig === 'no_dashboard_poll') {
                   navigate(`/bankaccountform${search}`);
                 }
               }}

--- a/client/routes/RouteHandlers.tsx
+++ b/client/routes/RouteHandlers.tsx
@@ -69,8 +69,8 @@ export const CustomGatedRoute = ({
   children: React.ReactNode;
 }): JSX.Element => {
   const {search} = useLocation();
-  const {stripeAccount} = useSession();
-  if (stripeAccount?.type !== 'custom') {
+  const {user} = useSession();
+  if (user?.accountConfig !== 'no_dashboard_poll') {
     return <Navigate to={`/reservations${search}`} replace />;
   }
   return <>{children}</>;

--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -427,17 +427,31 @@ function getStripeAccountId(req: any) {
  */
 app.post('/account_session', stripeAccountRequired, async (req, res) => {
   try {
+    const user = req.user!;
+    // FurEver enables external account collection for all accounts except ones where the platform owns requirements collection (otherwise known as custom)
+    const external_account_collection =
+      user.accountConfig === 'no_dashboard_poll';
+
     // This should contain a list of all components used in FurEver
     const accountSessionComponentsParams: Stripe.AccountSessionCreateParams.Components =
       {
         account_management: {
           enabled: true,
+          features: {
+            external_account_collection,
+          },
         },
         account_onboarding: {
           enabled: true,
+          features: {
+            external_account_collection,
+          },
         },
         notification_banner: {
           enabled: true,
+          features: {
+            external_account_collection,
+          },
         },
         payments: {
           enabled: true,
@@ -456,6 +470,7 @@ app.post('/account_session', stripeAccountRequired, async (req, res) => {
           enabled: true,
           features: {
             money_movement: true,
+            external_account_collection,
           },
         },
         financial_account_transactions: {

--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -158,9 +158,7 @@ const createPaymentIntentForNonCardPayments = async (
   }
 };
 
-function getAccountParams(
-  accountConfiguration: string
-): Stripe.AccountCreateParams {
+function getAccountParams(accountConfig: string): Stripe.AccountCreateParams {
   let type: Stripe.Account.Type | undefined = undefined;
   let capabilities: Stripe.AccountCreateParams.Capabilities | undefined = {
     card_payments: {
@@ -171,7 +169,7 @@ function getAccountParams(
     },
   };
   let controller: Stripe.AccountCreateParams.Controller | undefined = undefined;
-  switch (accountConfiguration) {
+  switch (accountConfig) {
     case 'no_dashboard_poll':
       controller = {
         losses: {
@@ -216,7 +214,7 @@ function getAccountParams(
       };
       break;
     default:
-      throw new Error('Invalid account configuration:' + accountConfiguration);
+      throw new Error('Invalid account configuration:' + accountConfig);
   }
 
   return {
@@ -238,7 +236,7 @@ interface Test extends Request {
 app.post('/create-account', userRequired, async (req, res) => {
   try {
     const user = req.user!;
-    user.set(req.body); // Try to update the logged-in salon using the newly entered profile data
+    user.set(req.body); // Update the logged-in salon using the newly entered profile data
     await user.save();
 
     let accountId = user.stripeAccountId;
@@ -249,7 +247,7 @@ app.post('/create-account', userRequired, async (req, res) => {
     }
 
     const shouldPrefill = req.body.prefill;
-    const accountConfiguration = req.body.accountConfiguration;
+    const accountConfig = req.body.accountConfig;
 
     // Create a Stripe account for this user if one does not exist already
     if (accountId == undefined) {
@@ -267,7 +265,7 @@ app.post('/create-account', userRequired, async (req, res) => {
         });
       }
 
-      const accountConfigParams = getAccountParams(accountConfiguration);
+      const accountConfigParams = getAccountParams(accountConfig);
 
       // Define the parameters to create a new Stripe account with
       let accountParams: Stripe.AccountCreateParams = {
@@ -428,9 +426,10 @@ function getStripeAccountId(req: any) {
 app.post('/account_session', stripeAccountRequired, async (req, res) => {
   try {
     const user = req.user!;
+
     // FurEver enables external account collection for all accounts except ones where the platform owns requirements collection (otherwise known as custom)
     const external_account_collection =
-      user.accountConfig === 'no_dashboard_poll';
+      user.accountConfig !== 'no_dashboard_poll';
 
     // This should contain a list of all components used in FurEver
     const accountSessionComponentsParams: Stripe.AccountSessionCreateParams.Components =

--- a/types/express.d.ts
+++ b/types/express.d.ts
@@ -17,6 +17,7 @@ declare global {
       firstName: string;
       lastName: string;
       stripeAccountId: string;
+      accountConfig: string;
 
       // MongoDB methods
       isModified: (field: string) => boolean;


### PR DESCRIPTION
Also fixed an issue with custom onboarding where we were checking for `custom`, however the newly created accounts are not custom.

The UX is not impacted.