### PR TITLE
Only request Issuing + Treasury components if those capabilities exist in redesign

### DIFF
--- a/app/(dashboard)/finances/page.tsx
+++ b/app/(dashboard)/finances/page.tsx
@@ -66,6 +66,7 @@ export default function Finances() {
           capabilities: capabilities,
         }),
       });
+
       if (res.ok) {
         setButtonLoading(false);
         // Page must reload to show the new components

--- a/app/(dashboard)/finances/page.tsx
+++ b/app/(dashboard)/finances/page.tsx
@@ -66,9 +66,9 @@ export default function Finances() {
           capabilities: capabilities,
         }),
       });
-
       if (res.ok) {
         setButtonLoading(false);
+        // Page must reload to show the new components
         window.location.reload();
       }
     } catch (e) {

--- a/app/api/account_session/route.ts
+++ b/app/api/account_session/route.ts
@@ -54,6 +54,37 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const account = await stripe.accounts.retrieve(stripeAccountId);
+    // We can only request the components if the account has both issuing and treasury capabilities
+    const hasIssuingAndTreasury = ['card_issuing', 'treasury'].every(
+      (capability) =>
+        Object.keys(account?.capabilities || []).includes(capability)
+    );
+    const issuingAndTreasuryComponents = {
+      issuing_card: {
+        enabled: true,
+      },
+      issuing_cards_list: {
+        enabled: true,
+        features: {
+          card_management: true,
+          cardholder_management: true,
+        },
+      },
+      financial_account: {
+        enabled: true,
+        features: {
+          money_movement: true,
+        },
+      },
+      financial_account_transactions: {
+        enabled: true,
+        features: {
+          card_spend_dispute_management: true,
+        },
+      },
+    };
+
     const accountSession = await stripe.accountSessions.create({
       account: stripeAccountId,
       components: {
@@ -79,28 +110,7 @@ export async function POST(req: NextRequest) {
         capital_overview: {
           enabled: true,
         },
-        financial_account: {
-          enabled: true,
-          features: {
-            money_movement: true,
-          },
-        },
-        issuing_cards_list: {
-          enabled: true,
-          features: {
-            card_management: true,
-            cardholder_management: true,
-          },
-        },
-        issuing_card: {
-          enabled: true,
-        },
-        financial_account_transactions: {
-          enabled: true,
-          features: {
-            card_spend_dispute_management: true,
-          },
-        },
+        ...(hasIssuingAndTreasury ? issuingAndTreasuryComponents : {}),
       },
     });
 


### PR DESCRIPTION
Same as #142 but for the redesign. Much easier to reason about here as the page already does a full reload. 