### PR TITLE
Add a Tools button to create Checkout sessions from the account settings page

### DIFF
--- a/app/api/payment_method_settings/create_checkout_session/route.ts
+++ b/app/api/payment_method_settings/create_checkout_session/route.ts
@@ -1,0 +1,106 @@
+import {Stripe} from 'stripe';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+import {getServerSession} from 'next-auth';
+import { NextRequest } from 'next/server';
+
+const customers = [
+  {
+    email: 'labradoodle@stripe.com',
+    name: 'Odie',
+    description: 'Full grooming package for large Labradoodle',
+  },
+  {
+    email: 'poodle@stripe.com',
+    name: 'Snoopy ',
+    description: 'Nail trimming for toy Poodle',
+  },
+  {
+    email: 'golden_retriever@stripe.com',
+    name: 'Dug',
+    description:
+    'Hydro surge warm water shampoo & conditioner for Golden Retriever',
+  },
+  {
+    email: 'siamese_cat@stripe.com',
+    name: 'Garfield',
+    description: 'Flea and tick treatments for Siamese cat',
+  },
+  {
+    email: 'argente_rabbit@stripe.com',
+    name: 'Bugs Bunny',
+    description: 'Fur brushing and trimming for Argente Rabbit',
+  },
+];
+
+function getRandomInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+/**
+* Generates a test Checkout Session for a merchant. This is used to show the payment
+* methods that are available after toggling them in the Payment Method settings.
+*/
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    let redirectUrl;
+    if (process.env.NODE_ENV === 'development') {
+      redirectUrl = 'http://localhost:3000/settings';
+    } else if (process.env.NODE_ENV === 'production') {
+      redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL}/settings`;
+    }
+    
+    const params = await req.json();
+
+    const currency = (params.currency && params.currency !== '_default') ? params.currency : session?.user.stripeAccount.default_currency;
+    const amount = params.amount ? parseFloat(params.amount) * 100 : getRandomInt(4000,12000);
+    
+    const {description: nameAndDescription} =
+    customers[Math.floor(Math.random() * customers.length)];
+    
+    const checkoutSessionResponse = await stripe.checkout.sessions.create({
+      line_items: [
+        {
+          price_data: {
+            currency,
+            unit_amount: amount,
+            product_data: {
+              name: nameAndDescription,
+              description: nameAndDescription,
+            },
+          },
+          quantity: 1,
+        },
+      ],
+      payment_intent_data: {
+        description: nameAndDescription,
+        statement_descriptor: process.env.APP_NAME,
+      },
+      mode: 'payment',
+      success_url: redirectUrl,
+      cancel_url: redirectUrl,
+    }, {
+      stripeAccount: session?.user.stripeAccount.id,
+    });
+    
+    console.log('Created checkout session!', checkoutSessionResponse);
+    
+    if (!checkoutSessionResponse || !checkoutSessionResponse.url) {
+      throw new Error('Session URL was not returned');
+    }
+    
+    return new Response(
+      JSON.stringify({
+        checkoutSessionResponse,
+      }),
+      {status: 200, headers: {'Content-Type': 'application/json'}}
+    );
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to create a checkout session',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/setup_accounts/create_risk_intervention/route.ts
+++ b/app/api/setup_accounts/create_risk_intervention/route.ts
@@ -32,7 +32,7 @@ export async function POST() {
     });
   } catch (error: any) {
     console.error(
-      'An error occurred when calling the Stripe API to create a checkout session',
+      'An error occurred when calling the Stripe API to create a risk intervention',
       error
     );
     return new Response(error.message, {status: 500});

--- a/app/components/ToolsPanel.tsx
+++ b/app/components/ToolsPanel.tsx
@@ -90,7 +90,7 @@ const ToolsPanel = () => {
 
   const CustomTools = () => {
     return (
-      <div className="mt-4 flex flex-col items-stretch">
+      <div className="mt-4 gap-2 flex flex-col items-stretch">
         {actions.map(
           (action) =>
             pathname.includes(action.href) &&

--- a/app/components/ToolsPanel.tsx
+++ b/app/components/ToolsPanel.tsx
@@ -41,6 +41,7 @@ import OverlaySelector from './Tools/OverlaySelector';
 import CreateInterventionsButton from './testdata/CreateInterventionsButton';
 import CreatePayoutsButton from './testdata/CreatePayoutsButton';
 import CreateFinancialCreditButton from './testdata/CreateFinancialCreditButton';
+import CreateCheckoutSessionButton from './testdata/CreateCheckoutSessionButton';
 
 const ToolsPanel = () => {
   const pathname = usePathname();
@@ -75,6 +76,11 @@ const ToolsPanel = () => {
       description: 'Simulate a risk intervention',
       href: '/settings',
       component: CreateInterventionsButton,
+    },
+    {
+      description: 'Create a Checkout Session',
+      href: '/settings',
+      component: CreateCheckoutSessionButton,
     },
     {
       description: 'Simulate a risk intervention',

--- a/app/components/ToolsPanel.tsx
+++ b/app/components/ToolsPanel.tsx
@@ -96,7 +96,7 @@ const ToolsPanel = () => {
 
   const CustomTools = () => {
     return (
-      <div className="mt-4 gap-2 flex flex-col items-stretch">
+      <div className="mt-4 flex flex-col items-stretch gap-2">
         {actions.map(
           (action) =>
             pathname.includes(action.href) &&

--- a/app/components/testdata/CreateCheckoutSessionButton.tsx
+++ b/app/components/testdata/CreateCheckoutSessionButton.tsx
@@ -30,7 +30,7 @@ import {
 import {zodResolver} from '@hookform/resolvers/zod';
 import {ControllerRenderProps, useForm} from 'react-hook-form';
 import {z} from 'zod';
-import { useRouter} from 'next/navigation';
+import {useRouter} from 'next/navigation';
 import {LoaderCircle} from 'lucide-react';
 
 const formSchema = z.object({
@@ -85,7 +85,11 @@ function CurrencySelect({
   );
 }
 
-export default function CreateCheckoutSessionButton({classes}: {classes?: string}) {
+export default function CreateCheckoutSessionButton({
+  classes,
+}: {
+  classes?: string;
+}) {
   const [open, setOpen] = React.useState(false);
   const router = useRouter();
   const form = useForm<z.infer<typeof formSchema>>({
@@ -106,10 +110,13 @@ export default function CreateCheckoutSessionButton({classes}: {classes?: string
       currency: values.currency,
     };
 
-    const response = await fetch('/api/payment_method_settings/create_checkout_session', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    });
+    const response = await fetch(
+      '/api/payment_method_settings/create_checkout_session',
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
 
     if (!response.ok) {
       // Handle errors on the client side here
@@ -117,7 +124,6 @@ export default function CreateCheckoutSessionButton({classes}: {classes?: string
       console.warn('An error occurred: ', error);
       return undefined;
     } else {
-      
       const json = await response.json();
 
       const redirectUrl = json?.checkoutSessionResponse?.url;
@@ -137,7 +143,6 @@ export default function CreateCheckoutSessionButton({classes}: {classes?: string
       <>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            
             <FormField
               control={form.control}
               name="amount"
@@ -149,7 +154,7 @@ export default function CreateCheckoutSessionButton({classes}: {classes?: string
                       {...field}
                       placeholder="Leave blank for a random amount"
                       type="number"
-                      step="0.01" 
+                      step="0.01"
                     />
                   </FormControl>
                   <FormMessage />

--- a/app/components/testdata/CreateCheckoutSessionButton.tsx
+++ b/app/components/testdata/CreateCheckoutSessionButton.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import * as React from 'react';
+import {Button} from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
+import {Input} from '@/components/ui/input';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {ControllerRenderProps, useForm} from 'react-hook-form';
+import {z} from 'zod';
+import { useRouter} from 'next/navigation';
+import {LoaderCircle} from 'lucide-react';
+
+const formSchema = z.object({
+  amount: z.string(),
+  currency: z.string(),
+});
+
+type Currency =
+  | '_default'
+  | 'aed'
+  | 'aud'
+  | 'cad'
+  | 'cny'
+  | 'eur'
+  | 'gbp'
+  | 'inr'
+  | 'jpy'
+  | 'sgd'
+  | 'usd';
+const CurrencyOptions: Record<Currency, string> = {
+  _default: 'Default',
+  aed: 'AED',
+  aud: 'AUD',
+  cad: 'CAD',
+  cny: 'CNY',
+  eur: 'EUR',
+  gbp: 'GBP',
+  inr: 'INR',
+  jpy: 'JPY',
+  sgd: 'SGD',
+  usd: 'USD',
+};
+
+function CurrencySelect({
+  field,
+}: {
+  field: ControllerRenderProps<z.infer<typeof formSchema>, 'currency'>;
+}) {
+  return (
+    <Select {...field} onValueChange={(value) => field.onChange(value)}>
+      <SelectTrigger className="mt-1">
+        <SelectValue>{CurrencyOptions[field.value as Currency]}</SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {Object.keys(CurrencyOptions).map((key) => (
+          <SelectItem key={key} value={key}>
+            {CurrencyOptions[key as Currency]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export default function CreateCheckoutSessionButton({classes}: {classes?: string}) {
+  const [open, setOpen] = React.useState(false);
+  const router = useRouter();
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      amount: '',
+      currency: '_default',
+    },
+  });
+
+  const [loading, setLoading] = React.useState(false);
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    setLoading(true);
+    console.log('creating checkout session with data: ', values);
+    const data = {
+      amount: values.amount,
+      currency: values.currency,
+    };
+
+    const response = await fetch('/api/payment_method_settings/create_checkout_session', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      // Handle errors on the client side here
+      const {error} = await response.json();
+      console.warn('An error occurred: ', error);
+      return undefined;
+    } else {
+      
+      const json = await response.json();
+
+      const redirectUrl = json?.checkoutSessionResponse?.url;
+
+      // Redirect to Checkout
+      if (redirectUrl) {
+        window.location.href = redirectUrl;
+      }
+
+      setLoading(false);
+      setOpen(false);
+    }
+  };
+
+  const CreateCheckoutSessionForm = () => {
+    return (
+      <>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({field}) => (
+                <FormItem>
+                  <FormLabel>Amount</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="Leave blank for a random amount"
+                      type="number"
+                      step="0.01" 
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="currency"
+              render={({field}) => (
+                <FormItem>
+                  <FormLabel>Currency</FormLabel>
+                  <FormControl>
+                    <CurrencySelect field={field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flew-row flex justify-end space-x-2">
+              <DialogClose asChild>
+                <Button type="button" variant="secondary">
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button variant="default" type="submit" disabled={loading}>
+                Launch Checkout Session{' '}
+                {loading && (
+                  <LoaderCircle
+                    className="ml-2 animate-spin items-center"
+                    size={20}
+                  />
+                )}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </>
+    );
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          className={`${classes || 'border'}`}
+          variant="secondary"
+          size="sm"
+        >
+          Create test Checkout Session
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="p-4 text-primary sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Create test Checkout Session</DialogTitle>
+          <DialogDescription>
+            Simulate a grooming payment by creating a{' '}
+            <a
+              target="blank"
+              className="font-medium text-accent"
+              href="https://stripe.com/docs/api/checkout/sessions"
+            >
+              Checkout Session
+            </a>
+            .
+          </DialogDescription>
+        </DialogHeader>
+        <CreateCheckoutSessionForm />
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

When trying out the embedded payment method settings component, it's important for the user to be able to quickly launch into Checkout so that they can see how these payment methods are presented to buyers. This PR introduces a "Create Checkout Session" button to the Tools panel on the settings page. Users can specify the following parameters:

* Amount (defaults to a random number between `4000` and `12000`)
* Currency (defaults to the merchant's default currency)

## Screen recording




https://github.com/stripe/stripe-connect-furever-demo/assets/95376121/cd1b9592-76a6-4327-b033-8468e779afe1




## Screenshots

Tools panel:
<img width="2055" alt="image" src="https://github.com/stripe/stripe-connect-furever-demo/assets/95376121/083aab84-c840-4ced-a197-ec3b62d487e5">

Create Checkout Session dialog:
<img width="470" alt="image" src="https://github.com/stripe/stripe-connect-furever-demo/assets/95376121/a018d5a3-c537-44b8-b6d3-55671f7e9a43">

Launching a Checkout session with amount and currency filled:
<img width="1040" alt="image" src="https://github.com/stripe/stripe-connect-furever-demo/assets/95376121/50e31039-dddf-4553-9404-79d21827f770">
