### PR TITLE
Fix redirect URLs when creating checkout sessions

### DIFF
--- a/app/api/debug/create_checkout_session/route.ts
+++ b/app/api/debug/create_checkout_session/route.ts
@@ -40,12 +40,7 @@ export async function POST() {
   try {
     const session = await getServerSession(authOptions);
     const currency = 'usd';
-    let redirectUrl;
-    if (process.env.NODE_ENV === 'development') {
-      redirectUrl = 'http://localhost:3000/payments';
-    } else if (process.env.NODE_ENV === 'production') {
-      redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL}/payments`;
-    }
+    const redirectUrl = `${process.env.NEXTAUTH_URL}/payments`;
 
     const {description: nameAndDescription} =
       customers[Math.floor(Math.random() * customers.length)];

--- a/app/api/payment_method_settings/create_checkout_session/route.ts
+++ b/app/api/payment_method_settings/create_checkout_session/route.ts
@@ -44,12 +44,7 @@ function getRandomInt(min: number, max: number) {
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    let redirectUrl;
-    if (process.env.NODE_ENV === 'development') {
-      redirectUrl = 'http://localhost:3000/settings';
-    } else if (process.env.NODE_ENV === 'production') {
-      redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL}/settings`;
-    }
+    const redirectUrl = `${process.env.NEXTAUTH_URL}/settings`;
 
     const params = await req.json();
 


### PR DESCRIPTION
We were populating redirect URLs from a nonexistent env variable which causes the Stripe API to return 400s when we tried to create Checkout sessions in production. This PR changes the two affected callsites to use `$NEXTAUTH_URL` which _is_ populated in both dev and prod. This fixes two actions that were broken in prod:

* `create_checkout_session` debug command (cmd+shift+k)
* `create_checkout_session` API on the account settings page