### PR TITLE
Add margin to account onboarding container

### DIFF
--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -15,7 +15,10 @@ export default function Onboarding() {
     stripeAccount?.controller?.requirement_collection === 'application';
 
   return (
-    <EmbeddedComponentContainer componentName="AccountOnboarding">
+    <EmbeddedComponentContainer
+      componentName="AccountOnboarding"
+      className="mt-5"
+    >
       <ConnectAccountOnboarding
         onExit={() => {
           if (isCustom) {


### PR DESCRIPTION
<img width="586" alt="image" src="https://github.com/stripe/stripe-connect-furever-demo/assets/124314569/51ab8a5b-0481-443d-953e-51b1d4d84ef3">

Adds margin to the top to account for hover docs