### PR TITLE
Turn external account collection off for custom accounts

### DIFF
--- a/app/api/account_session/route.ts
+++ b/app/api/account_session/route.ts
@@ -55,6 +55,12 @@ export async function POST(req: NextRequest) {
     }
 
     const account = await stripe.accounts.retrieve(stripeAccountId);
+
+  const isCustom =
+  account?.controller?.stripe_dashboard?.type === 'none' &&
+  account?.controller?.losses?.payments === 'application' &&
+  account?.controller?.requirement_collection === 'application';
+  
     // We can only request the components if the account has both issuing and treasury capabilities
     const hasIssuingAndTreasury = ['card_issuing', 'treasury'].every(
       (capability) =>
@@ -98,15 +104,16 @@ export async function POST(req: NextRequest) {
             instant_payouts: true,
             standard_payouts: true,
             edit_payout_schedule: true,
+            external_account_collection: !isCustom,
           },
         },
         // Connect
-        account_management: {enabled: true},
-        account_onboarding: {enabled: true},
+        account_management: {enabled: true, features:{external_account_collection: !isCustom}},
+        account_onboarding: {enabled: true, features:{external_account_collection: !isCustom}},
         // @ts-ignore
         payment_method_settings: {enabled: true},
         documents: {enabled: true},
-        notification_banner: {enabled: true},
+        notification_banner: {enabled: true, features:{external_account_collection: !isCustom}},
         capital_overview: {
           enabled: true,
         },

--- a/app/api/account_session/route.ts
+++ b/app/api/account_session/route.ts
@@ -56,11 +56,11 @@ export async function POST(req: NextRequest) {
 
     const account = await stripe.accounts.retrieve(stripeAccountId);
 
-  const isCustom =
-  account?.controller?.stripe_dashboard?.type === 'none' &&
-  account?.controller?.losses?.payments === 'application' &&
-  account?.controller?.requirement_collection === 'application';
-  
+    const isCustom =
+      account?.controller?.stripe_dashboard?.type === 'none' &&
+      account?.controller?.losses?.payments === 'application' &&
+      account?.controller?.requirement_collection === 'application';
+
     // We can only request the components if the account has both issuing and treasury capabilities
     const hasIssuingAndTreasury = ['card_issuing', 'treasury'].every(
       (capability) =>
@@ -108,12 +108,21 @@ export async function POST(req: NextRequest) {
           },
         },
         // Connect
-        account_management: {enabled: true, features:{external_account_collection: !isCustom}},
-        account_onboarding: {enabled: true, features:{external_account_collection: !isCustom}},
+        account_management: {
+          enabled: true,
+          features: {external_account_collection: !isCustom},
+        },
+        account_onboarding: {
+          enabled: true,
+          features: {external_account_collection: !isCustom},
+        },
         // @ts-ignore
         payment_method_settings: {enabled: true},
         documents: {enabled: true},
-        notification_banner: {enabled: true, features:{external_account_collection: !isCustom}},
+        notification_banner: {
+          enabled: true,
+          features: {external_account_collection: !isCustom},
+        },
         capital_overview: {
           enabled: true,
         },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.51.1",
     "sharp": "^0.33.4",
-    "stripe": "^15.4.0-beta.1",
+    "stripe": "^15.12.0-beta.1",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4302,10 +4302,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@^15.4.0-beta.1:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-15.5.0.tgz#4e7a9b5b6f9ef4b975f1714c14f55ed646b3de05"
-  integrity sha512-c04ToET4ZUzoeSh2rWarXCPNa2+6YzkwNAcWaT4axYRlN/u1XMkz9+inouNsXWjeT6ttBrp1twz10x/sCbWLpQ==
+stripe@^15.12.0-beta.1:
+  version "15.12.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-15.12.0.tgz#a30c242861f9c97dd31d3078fb0673d9bd10efe2"
+  integrity sha512-slTbYS1WhRJXVB8YXU8fgHizkUrM9KJyrw4Dd8pLEwzKHYyQTIE46EePC2MVbSDZdE24o1GdNtzmJV4PrPpmJA==
   dependencies:
     "@types/node" ">=8.1.0"
     qs "^6.11.0"


### PR DESCRIPTION
External account collection should be off for custom accounts, this specifies the parameter in account session to be false. Now custom users do not have to authenticate or claim their account to see account management

https://github.com/user-attachments/assets/11cd1625-ab9e-4a4b-8066-be8cc895c9aa

