### PR TITLE
Prefill with business name and type if they exist, change email domains

### DIFF
--- a/app/(auth)/business/form.tsx
+++ b/app/(auth)/business/form.tsx
@@ -36,8 +36,8 @@ import {
 import type {FeePayer, StripeDashboardType} from '@/types/account';
 
 const businessTypeLabels = {
-  independent_salon: 'Independent salon',
-  chain_of_salons: 'Chain of salons',
+  individual: 'Independent salon',
+  company: 'Chain of salons',
   other: 'Other',
 };
 
@@ -269,7 +269,7 @@ export default function BusinessDetailsForm({email}: {email: string}) {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      businessType: 'independent_salon',
+      businessType: 'individual',
       businessName: '',
       country: 'US',
       stripeDashboardType: 'none',

--- a/app/api/account_session/route.ts
+++ b/app/api/account_session/route.ts
@@ -108,7 +108,6 @@ export async function POST(req: NextRequest) {
           },
         },
         // Connect
-<<<<<<< HEAD
         account_management: {
           enabled: true,
           features: {external_account_collection: !isCustom},
@@ -124,14 +123,6 @@ export async function POST(req: NextRequest) {
           enabled: true,
           features: {external_account_collection: !isCustom},
         },
-=======
-        account_management: {enabled: true, features:{external_account_collection: !isCustom}},
-        account_onboarding: {enabled: true, features:{external_account_collection: !isCustom}},
-        // @ts-ignore
-        payment_method_settings: {enabled: true},
-        documents: {enabled: true},
-        notification_banner: {enabled: true, features:{external_account_collection: !isCustom}},
->>>>>>> 67f4d0e (turn off eac for custom)
         capital_overview: {
           enabled: true,
         },

--- a/app/api/account_session/route.ts
+++ b/app/api/account_session/route.ts
@@ -108,6 +108,7 @@ export async function POST(req: NextRequest) {
           },
         },
         // Connect
+<<<<<<< HEAD
         account_management: {
           enabled: true,
           features: {external_account_collection: !isCustom},
@@ -123,6 +124,14 @@ export async function POST(req: NextRequest) {
           enabled: true,
           features: {external_account_collection: !isCustom},
         },
+=======
+        account_management: {enabled: true, features:{external_account_collection: !isCustom}},
+        account_onboarding: {enabled: true, features:{external_account_collection: !isCustom}},
+        // @ts-ignore
+        payment_method_settings: {enabled: true},
+        documents: {enabled: true},
+        notification_banner: {enabled: true, features:{external_account_collection: !isCustom}},
+>>>>>>> 67f4d0e (turn off eac for custom)
         capital_overview: {
           enabled: true,
         },

--- a/app/api/setup_accounts/route.ts
+++ b/app/api/setup_accounts/route.ts
@@ -63,6 +63,7 @@ export async function POST() {
         },
         confirm: true,
         payment_method: 'pm_card_createDispute',
+        receipt_email: 'dispute_test@stripe.com',
       },
       {
         stripeAccount: accountId,

--- a/app/components/QuickstartButton.tsx
+++ b/app/components/QuickstartButton.tsx
@@ -191,7 +191,7 @@ const QuickstartButton = () => {
     const passwordWords = generate({exactly: 2, minLength: 5, maxLength: 12});
 
     await signIn('createprefilledaccount', {
-      email: `${salonName}_${emailNumber}@stripe.com`,
+      email: `${salonName}_${emailNumber}@furever.com`,
       password: `${passwordWords[0]}-${passwordWords[1]}-${passwordNumber}`,
       businessName: salonName,
       callbackUrl: '/home?shownux=true',

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,6 +10,10 @@ function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+function assertUnreachable(option: string) {
+  console.error(`Did not find a valid option for ${option}`);
+}
+
 export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
@@ -382,14 +386,14 @@ export const authOptions: AuthOptions = {
             console.log('Could not find an existing user for the email', email);
             return null;
           }
-          let businessType = undefined;
-
-          if (
-            credentials?.businessType === 'company' ||
-            credentials?.businessType === 'individual'
-          ) {
-            businessType =
-              credentials?.businessType as Stripe.AccountCreateParams.BusinessType;
+          let businessType: Stripe.Account.BusinessType;
+          switch (credentials?.businessType) {
+            case 'company':
+            case 'individual':
+              businessType = credentials?.businessType;
+            default:
+              assertUnreachable(credentials?.businessType);
+              businessType = 'individual'; // We default to individual, but rely on TS to catch missing cases
           }
 
           console.log('Creating stripe account for the email', email);

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,13 +10,6 @@ function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function assertUnreachable(x: never | undefined, message?: string) {
-  console.error(
-    message ?? 'Thing that should never be set is set',
-    JSON.parse(JSON.stringify(x))
-  );
-}
-
 export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
@@ -389,14 +382,14 @@ export const authOptions: AuthOptions = {
             console.log('Could not find an existing user for the email', email);
             return null;
           }
-          let businessType: Stripe.Account.BusinessType;
+          let businessType;
           switch (credentials?.businessType) {
             case 'company':
             case 'individual':
-              businessType = credentials?.businessType;
+              businessType =
+                credentials?.businessType as Stripe.AccountCreateParams.BusinessType;
             default:
-              assertUnreachable(credentials?.businessType);
-              businessType = 'individual'; // We default to individual, but rely on TS to catch missing cases
+              businessType = undefined; // We default to undefined so user can pick the business type during onboarding
           }
 
           console.log('Creating stripe account for the email', email);

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,8 +10,11 @@ function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function assertUnreachable(option: string) {
-  console.error(`Did not find a valid option for ${option}`);
+function assertUnreachable(x: never | undefined, message?: string) {
+  console.error(
+    message ?? 'Thing that should never be set is set',
+    JSON.parse(JSON.stringify(x))
+  );
 }
 
 export const authOptions: AuthOptions = {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,7 @@ import dbConnect from '@/lib/dbConnect';
 import Salon from '../app/models/salon';
 import {stripe} from '@/lib/stripe';
 import {resolveControllerParams} from './utils';
+import Stripe from 'stripe';
 
 function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -381,10 +382,23 @@ export const authOptions: AuthOptions = {
             console.log('Could not find an existing user for the email', email);
             return null;
           }
+          let businessType = undefined;
+
+          if (
+            credentials?.businessType === 'company' ||
+            credentials?.businessType === 'individual'
+          ) {
+            businessType =
+              credentials?.businessType as Stripe.AccountCreateParams.BusinessType;
+          }
 
           console.log('Creating stripe account for the email', email);
           const account = await stripe.accounts.create({
             country: credentials?.country || 'US',
+            business_type: businessType,
+            business_profile: {
+              name: credentials?.businessName || 'Furever Pet Salon',
+            },
             email: email,
             controller: resolveControllerParams({
               feePayer: credentials.feePayer,

--- a/types/account.ts
+++ b/types/account.ts
@@ -1,8 +1,4 @@
-export const businessTypes = [
-  'independent_salon',
-  'chain_of_salons',
-  'other',
-] as const;
+export const businessTypes = ['individual', 'company', 'other'] as const;
 export type BusinessType = (typeof businessTypes)[number];
 
 export const countries = [


### PR DESCRIPTION
Disputes now have a customer
<img width="676" alt="image" src="https://github.com/user-attachments/assets/bf60d386-498d-4985-bec9-9903ce9ffed2">

Business name and type are prefilled if they are specified:

Individual (taken straight to identity info page):
https://github.com/user-attachments/assets/b32e74af-db84-4c13-b764-a118f349055f
Other (have to pick)
https://github.com/user-attachments/assets/7f845753-d4b0-446d-a8bd-a88896b6e6da

Also tested with company but did not screen record

