### PR TITLE
Remove Indonesia from country list

### DIFF
--- a/types/account.ts
+++ b/types/account.ts
@@ -46,7 +46,6 @@ export const countries = [
   'HU',
   'IS',
   'IN',
-  'ID',
   'IE',
   'IL',
   'IT',


### PR DESCRIPTION
Remove Indonesia from the list of country options in the business sign up page. Only Indonesian platforms can create Indonesian accounts, so selecting Indonesia on Furever would cause an error.

https://github.com/user-attachments/assets/12ac66e5-0365-458e-80fc-d2c61ff3c2a5

