### PR TITLE
Removing the API version `embedded_connect_beta` flag

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -2,5 +2,5 @@ import Stripe from 'stripe';
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
   // @ts-ignore
-  apiVersion: '2023-10-16; embedded_connect_beta=v2',
+  apiVersion: '2023-10-16',
 });


### PR DESCRIPTION
`embedded_connect_beta=v2` is no longer required (and in fact causes an error)