### PR TITLE
Fix payment capture docs url

### DIFF
--- a/app/api/setup_accounts/create_charges/route.ts
+++ b/app/api/setup_accounts/create_charges/route.ts
@@ -235,7 +235,7 @@ export async function POST(req: NextRequest) {
                 confirm: true,
                 ...(status === 'card_uncaptured'
                   ? {
-                      capture_method: 'manual', // https://stripeSdk.com/docs/payments/place-a-hold-on-a-payment-method
+                      capture_method: 'manual', // https://stripe.com/docs/payments/place-a-hold-on-a-payment-method
                     }
                   : {}),
               },


### PR DESCRIPTION
Fixing the url for https://docs.stripe.com/payments/place-a-hold-on-a-payment-method 