### PR TITLE
Show form error if login credentials are incorrect

### DIFF
--- a/app/(auth)/login/form.tsx
+++ b/app/(auth)/login/form.tsx
@@ -36,15 +36,26 @@ export default function LoginForm() {
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
-      await signIn('login', {
+      const result = await signIn('login', {
         email: values.email,
         password: values.password,
         redirect: false,
       });
 
-      router.push('/home');
+      if (result?.error) {
+        form.setError('root', {
+          type: 'manual',
+          message: 'Invalid email or password. Please try again.',
+        });
+      } else if (result?.ok) {
+        router.push('/home');
+      }
     } catch (error: any) {
       console.error('An error occurred when signing in', error);
+      form.setError('root', {
+        type: 'manual',
+        message: 'An unexpected error occurred. Please try again.',
+      });
     }
   };
 
@@ -108,6 +119,11 @@ export default function LoginForm() {
             </>
           )}
         </Button>
+        {form.formState.errors.root && (
+          <p className="text-sm text-red-500">
+            {form.formState.errors.root.message}
+          </p>
+        )}
       </form>
     </Form>
   );

--- a/app/(auth)/signup/form.tsx
+++ b/app/(auth)/signup/form.tsx
@@ -36,13 +36,21 @@ export default function SignupForm() {
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
-      await signIn('signup', {
+      const result = await signIn('signup', {
         email: values.email,
         password: values.password,
         redirect: false,
       });
 
-      router.push('/business');
+      if (result?.error) {
+        // Just assume the error is because the email is already in use
+        form.setError('root', {
+          type: 'manual',
+          message: 'The email is already in use.',
+        });
+      } else if (result?.ok) {
+        router.push('/business');
+      }
     } catch (error: any) {
       console.error('An error occurred when signing in', error);
     }
@@ -106,6 +114,11 @@ export default function SignupForm() {
             </div>
           )}
         </Button>
+        {form.formState.errors.root && (
+          <p className="text-sm text-red-500">
+            {form.formState.errors.root.message}
+          </p>
+        )}
       </form>
     </Form>
   );


### PR DESCRIPTION
![CleanShot 2024-10-23 at 14 44 13@2x](https://github.com/user-attachments/assets/b75fb1c3-e02d-43bc-9c33-d795fa26b920)

Previously you could log in with bad credentials as the code path would always redirect you to `/home`. Now you're prevented!

![CleanShot 2024-10-23 at 14 56 47@2x](https://github.com/user-attachments/assets/cbbc7c74-386e-4c9c-82eb-0ad0e8a9c66e)

Also, we didn't check for errors when you attempted to sign up with an email that is already in use.