### PR TITLE
Add disable_stripe_user_authentication to Issuing Cards List component

### DIFF
--- a/app/api/account_session/route.ts
+++ b/app/api/account_session/route.ts
@@ -83,6 +83,7 @@ export async function POST(req: NextRequest) {
           cardholder_management: true,
           card_spend_dispute_management: true,
           spend_control_management: true,
+          disable_stripe_user_authentication: isCustom,
         },
       },
       financial_account: {


### PR DESCRIPTION
We'll be adding validation to ensure the disable_stripe_user_authentication feature is enabled or disabled across all components. We should explicitly enable this feature to match with the other components that take in the feature (i.e. only enable it for custom CAs).

Tested this locally and verified the components load as expected.
![Screenshot 2024-12-18 at 1 54 19 PM](https://github.com/user-attachments/assets/6cf9ceb8-650c-48e6-b66c-c6bb8ff3450e)
![Screenshot 2024-12-18 at 1 54 27 PM](https://github.com/user-attachments/assets/37d7f58d-7963-4bbd-9936-019a933785d9)
