### PR TITLE
Add express login link to furever

### DIFF
--- a/app/(dashboard)/settings/layout.tsx
+++ b/app/(dashboard)/settings/layout.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import {signOut, useSession} from 'next-auth/react';
+import {signOut} from 'next-auth/react';
 import SubNav from '@/app/components/SubNav';
 import {Button} from '@/components/ui/button';
 import {useConnectJSContext} from '@/app/hooks/EmbeddedComponentProvider';
-import {useMemo} from 'react';
 import {ExternalLink} from 'lucide-react';
 import {useExpressDashboardLoginLink} from '@/app/hooks/useExpressDashboardLoginLink';
 

--- a/app/(dashboard)/settings/layout.tsx
+++ b/app/(dashboard)/settings/layout.tsx
@@ -6,6 +6,7 @@ import {Button} from '@/components/ui/button';
 import {useConnectJSContext} from '@/app/hooks/EmbeddedComponentProvider';
 import {useMemo} from 'react';
 import {ExternalLink} from 'lucide-react';
+import {useExpressDashboardLoginLink} from '@/app/hooks/useExpressDashboardLoginLink';
 
 export default function SettingsLayout({
   children,
@@ -13,21 +14,9 @@ export default function SettingsLayout({
   children: React.ReactNode;
 }>) {
   const connectJSContext = useConnectJSContext();
-  const {data: session} = useSession();
 
-  const hasExpressDashboardAccess =
-    session?.user?.stripeAccount?.controller?.stripe_dashboard?.type ===
-    'express';
-
-  const expressDashboardLoginLink = useMemo(async () => {
-    if (hasExpressDashboardAccess) {
-      const res = await fetch('/api/login_link');
-      const data = await res.json();
-      return data.url;
-    } else {
-      null;
-    }
-  }, [hasExpressDashboardAccess]);
+  const {hasExpressDashboardAccess, expressDashboardLoginLink} =
+    useExpressDashboardLoginLink();
 
   return (
     <>
@@ -50,12 +39,12 @@ export default function SettingsLayout({
                 className="text-md ml-2 self-end p-2 hover:bg-white/80 hover:text-primary"
                 variant="ghost"
                 onClick={async () => {
-                  window.open(await expressDashboardLoginLink, '_blank');
+                  window.open(expressDashboardLoginLink, '_blank');
                 }}
                 aria-label="Open Stripe Express Dashboard"
               >
                 Express Dashboard &nbsp;
-                <ExternalLink color="var(--accent)" size={20} />
+                <ExternalLink color="var(--subdued)" size={20} />
               </Button>
             </div>
           )}

--- a/app/(dashboard)/settings/layout.tsx
+++ b/app/(dashboard)/settings/layout.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import {signOut} from 'next-auth/react';
+import {signOut, useSession} from 'next-auth/react';
 import SubNav from '@/app/components/SubNav';
 import {Button} from '@/components/ui/button';
-import {Avatar, AvatarFallback, AvatarImage} from '@/components/ui/avatar';
 import {useConnectJSContext} from '@/app/hooks/EmbeddedComponentProvider';
+import {useMemo} from 'react';
+import {ExternalLink} from 'lucide-react';
 
 export default function SettingsLayout({
   children,
@@ -12,6 +13,22 @@ export default function SettingsLayout({
   children: React.ReactNode;
 }>) {
   const connectJSContext = useConnectJSContext();
+  const {data: session} = useSession();
+
+  const hasExpressDashboardAccess =
+    session?.user?.stripeAccount?.controller?.stripe_dashboard?.type ===
+    'express';
+
+  const expressDashboardLoginLink = useMemo(async () => {
+    if (hasExpressDashboardAccess) {
+      const res = await fetch('/api/login_link');
+      const data = await res.json();
+      return data.url;
+    } else {
+      null;
+    }
+  }, [hasExpressDashboardAccess]);
+
   return (
     <>
       <header className="flex flex-col justify-between md:flex-row">
@@ -27,6 +44,21 @@ export default function SettingsLayout({
               {path: '/settings/tax', label: 'Tax'},
             ]}
           />
+          {hasExpressDashboardAccess && (
+            <div>
+              <Button
+                className="text-md ml-2 self-end p-2 hover:bg-white/80 hover:text-primary"
+                variant="ghost"
+                onClick={async () => {
+                  window.open(await expressDashboardLoginLink, '_blank');
+                }}
+                aria-label="Open Stripe Express Dashboard"
+              >
+                Express Dashboard &nbsp;
+                <ExternalLink color="var(--accent)" size={20} />
+              </Button>
+            </div>
+          )}
           <div>
             <Button
               className="text-md ml-2 self-end p-2 hover:bg-white/80 hover:text-primary"

--- a/app/api/login_link/route.ts
+++ b/app/api/login_link/route.ts
@@ -1,0 +1,42 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    const stripeAccount = session?.user?.stripeAccount?.id;
+    if (!stripeAccount) {
+      console.error('No connected account found for user');
+      return new Response('No connected account found for user', {
+        status: 400,
+      });
+    }
+
+    if (
+      session.user.stripeAccount.controller?.stripe_dashboard?.type !==
+      'express'
+    ) {
+      console.error('User does not have access to Express dashboard');
+      return new Response('User does not have access to Express dashboard.', {
+        status: 400,
+      });
+    }
+
+    const link = await stripe.accounts.createLoginLink(stripeAccount);
+
+    return new Response(
+      JSON.stringify({
+        url: link.url,
+      }),
+      {status: 200, headers: {'Content-Type': 'application/json'}}
+    );
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to create a login link',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/hooks/useExpressDashboardLoginLink.tsx
+++ b/app/hooks/useExpressDashboardLoginLink.tsx
@@ -1,0 +1,25 @@
+import {useSession} from 'next-auth/react';
+import {useEffect, useState} from 'react';
+
+export const useExpressDashboardLoginLink = () => {
+  const {data: session} = useSession();
+
+  const hasExpressDashboardAccess =
+    session?.user?.stripeAccount?.controller?.stripe_dashboard?.type ===
+    'express';
+
+  const [expressDashboardLoginLink, setExpressDashboardLoginLink] =
+    useState<string>();
+
+  useEffect(() => {
+    const fetchLink = async () => {
+      const res = await fetch('/api/login_link');
+      const data = await res.json();
+      setExpressDashboardLoginLink(data.url);
+    };
+
+    fetchLink();
+  }, []);
+
+  return {hasExpressDashboardAccess, expressDashboardLoginLink};
+};


### PR DESCRIPTION
When merchant has express dashboard access, display link to open express dashboard



https://github.com/user-attachments/assets/86b48b4c-8e2b-482f-819f-da0642a4e492


