### PR TITLE
[capital-for-platforms] Add XS promo tile to homepage if Capital offer is available

### DIFF
--- a/app/(dashboard)/finances/financing/page.tsx
+++ b/app/(dashboard)/finances/financing/page.tsx
@@ -1,45 +1,10 @@
 'use client';
 
 import React, {useState, useEffect} from 'react';
-import {
-  ConnectCapitalFinancing,
-  ConnectCapitalFinancingApplication,
-  ConnectCapitalFinancingPromotion,
-  ConnectComponentsProvider,
-} from '@stripe/react-connect-js';
+import {ConnectCapitalFinancing} from '@stripe/react-connect-js';
 import Container from '@/app/components/Container';
 import EmbeddedComponentContainer from '@/app/components/EmbeddedComponentContainer';
-import {LandmarkIcon, LoaderCircle} from 'lucide-react';
-import {Button} from '@/components/ui/button';
-import {useFinancialAccount} from '@/app/hooks/useFinancialAccount';
-import {FinancingProductType} from '@stripe/connect-js';
-
-function CapitalFinancingPromotionSection() {
-  // Only show the financing offer if there is one to show
-  const [showFinancingOffer, setShowFinancingOffer] = React.useState(false);
-  const handleFinancingOfferLoaded = ({productType}: FinancingProductType) => {
-    switch (productType) {
-      case 'none':
-        setShowFinancingOffer(false);
-        break;
-      case 'standard':
-      case 'refill':
-        setShowFinancingOffer(true);
-        break;
-    }
-  };
-
-  return (
-    <Container className={showFinancingOffer ? '' : 'hidden'}>
-      <EmbeddedComponentContainer componentName="CapitalFinancingPromotion">
-        <ConnectCapitalFinancingPromotion
-          onEligibleFinancingOfferLoaded={handleFinancingOfferLoaded}
-          layout={'full'}
-        />
-      </EmbeddedComponentContainer>
-    </Container>
-  );
-}
+import {CapitalFinancingPromotionSection} from '@/app/components/CapitalFinancingPromotionSection';
 
 function CapitalFinancingSection() {
   return (

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -11,6 +11,7 @@ import {ConnectNotificationBanner} from '@stripe/react-connect-js';
 import {useSession} from 'next-auth/react';
 import {redirect} from 'next/navigation';
 import Container from '@/app/components/Container';
+import {CapitalFinancingPromotionSection} from '@/app/components/CapitalFinancingPromotionSection';
 
 export default function Dashboard() {
   const {data: session} = useSession();
@@ -48,7 +49,6 @@ export default function Dashboard() {
           />
         </EmbeddedComponentContainer>
       </div>
-
       <div className="flex flex-col items-start gap-2 md:gap-5 xl:flex-row">
         <Container className="flex w-full flex-1 flex-col p-5">
           <Schedule />
@@ -56,6 +56,10 @@ export default function Dashboard() {
         <div className="-order-1 flex w-full flex-col gap-2 md:gap-4 xl:order-2 xl:w-[30%]">
           <div className="flex flex-grow flex-col gap-2 md:gap-4 md:max-xl:flex-row">
             <BalanceWidget />
+            <CapitalFinancingPromotionSection
+              layout="banner"
+              className="w-full px-5"
+            />
             <RecentPaymentsWidget />
           </div>
           <h2 className="hidden pt-4 text-lg font-bold xl:block">

--- a/app/components/CapitalFinancingPromotionSection.tsx
+++ b/app/components/CapitalFinancingPromotionSection.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Container from './Container';
+import {ConnectCapitalFinancingPromotion} from '@stripe/react-connect-js';
+import {FinancingProductType} from '@stripe/connect-js';
+
+import EmbeddedComponentContainer from '@/app/components/EmbeddedComponentContainer';
+import type {FinancingPromotionLayoutType} from '@stripe/connect-js';
+
+export function CapitalFinancingPromotionSection({
+  className = '',
+  layout = 'full',
+}: {
+  className?: string;
+  layout?: FinancingPromotionLayoutType;
+}) {
+  // Only show the financing offer if there is one to show
+  const [showFinancingOffer, setShowFinancingOffer] = React.useState(false);
+  const handleFinancingOfferLoaded = ({productType}: FinancingProductType) => {
+    switch (productType) {
+      case 'none':
+        setShowFinancingOffer(false);
+        break;
+      case 'standard':
+      case 'refill':
+        setShowFinancingOffer(true);
+        break;
+    }
+  };
+
+  return (
+    <Container
+      className={[className, showFinancingOffer ? '' : 'hidden']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <EmbeddedComponentContainer componentName="CapitalFinancingPromotion">
+        <ConnectCapitalFinancingPromotion
+          onEligibleFinancingOfferLoaded={handleFinancingOfferLoaded}
+          layout={layout}
+        />
+      </EmbeddedComponentContainer>
+    </Container>
+  );
+}


### PR DESCRIPTION
Current behavior
 - There is a capital financing fullsize promotion on Finances->Financing page

New behavior
 - There is an XS Capital promo tile on homepage if a Capital offer is available

See screenshots for new behavior:

no offer state
<img width="1714" alt="Screenshot 2025-03-04 at 11 47 06 AM" src="https://github.com/user-attachments/assets/7577474d-d2ec-4fa7-a40a-84bfcfd50300" />

offer state
<img width="1714" alt="Screenshot 2025-03-04 at 11 46 44 AM" src="https://github.com/user-attachments/assets/69e05558-0f13-4193-a1d3-e8756a2299c1" />

Refactoring; no changes to Financing page itself:
<img width="1714" alt="Screenshot 2025-03-04 at 11 47 12 AM" src="https://github.com/user-attachments/assets/37d318ae-c3a1-4f5d-bfef-89031d012867" />

