### PR TITLE
Improve the errors of the forms

### DIFF
--- a/app/(auth)/login/form.tsx
+++ b/app/(auth)/login/form.tsx
@@ -17,24 +17,20 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import {Input} from '@/components/ui/input';
-
-const formSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-});
+import {UserFormSchema} from '@/lib/forms';
 
 export default function LoginForm() {
   const router = useRouter();
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<z.infer<typeof UserFormSchema>>({
+    resolver: zodResolver(UserFormSchema),
     defaultValues: {
       email: '',
       password: '',
     },
   });
 
-  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+  const onSubmit = async (values: z.infer<typeof UserFormSchema>) => {
     try {
       const result = await signIn('login', {
         email: values.email,

--- a/app/(auth)/signup/form.tsx
+++ b/app/(auth)/signup/form.tsx
@@ -17,24 +17,20 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import {Input} from '@/components/ui/input';
-
-const formSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-});
+import {UserFormSchema} from '@/lib/forms';
 
 export default function SignupForm() {
   const router = useRouter();
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<z.infer<typeof UserFormSchema>>({
+    resolver: zodResolver(UserFormSchema),
     defaultValues: {
       email: '',
       password: '',
     },
   });
 
-  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+  const onSubmit = async (values: z.infer<typeof UserFormSchema>) => {
     try {
       const result = await signIn('signup', {
         email: values.email,

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod';
+
+export const UserFormSchema = z.object({
+  email: z.string().email({message: 'Invalid email address'}),
+  password: z
+    .string({
+      required_error: 'Password is required',
+    })
+    .min(8, {message: 'Password must be 8 or more characters'}),
+});


### PR DESCRIPTION
The form for register and sign in both are the same fields. This centralizes them, and uses the same errors:

![2025-03-28-105746](https://github.com/user-attachments/assets/58f36b04-bb50-4bf3-80c6-2450a2df63ac)
