### PR TITLE
Add Capital Financing Buttons to Tools Panel to Manipulate Financing Offer States

### DIFF
--- a/app/api/capital/approve_test_financing/route.ts
+++ b/app/api/capital/approve_test_financing/route.ts
@@ -1,0 +1,35 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+
+export async function POST() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    const connected_account = session!.user.stripeAccount.id;
+    const offer = (
+      await stripe.capital.financingOffers.list({connected_account, limit: 1})
+    ).data
+      .filter((o) => o.status === 'accepted')
+      .at(0);
+
+    await stripe.rawRequest(
+      'POST',
+      `/v1/capital/financing_offers/${offer!.id}/payout`,
+      {}
+    );
+
+    return new Response(
+      JSON.stringify({
+        offer,
+      }),
+      {status: 200, headers: {'Content-Type': 'application/json'}}
+    );
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to payout test financing offer',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/capital/approve_test_financing/route.ts
+++ b/app/api/capital/approve_test_financing/route.ts
@@ -13,7 +13,7 @@ export async function POST() {
       .filter((o) => o.status === 'accepted')
       .at(0);
 
-    if (offer == undefined) {
+    if (offer === undefined) {
       throw Error(
         'Unable to find offer with status `accepted` for connected account: ' +
           connected_account

--- a/app/api/capital/approve_test_financing/route.ts
+++ b/app/api/capital/approve_test_financing/route.ts
@@ -13,6 +13,13 @@ export async function POST() {
       .filter((o) => o.status === 'accepted')
       .at(0);
 
+    if (offer == undefined) {
+      throw Error(
+        'Unable to find offer with status `accepted` for connected account: ' +
+          connected_account
+      );
+    }
+
     await stripe.rawRequest(
       'POST',
       `/v1/capital/financing_offers/${offer!.id}/payout`,

--- a/app/api/capital/create_test_financing/route.ts
+++ b/app/api/capital/create_test_financing/route.ts
@@ -1,0 +1,40 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+import {NextRequest} from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    const connected_account = session!.user.stripeAccount.id;
+
+    const state = (await req.json())['offerState'] || 'delivered';
+
+    await stripe.rawRequest('POST', '/v1/capital/financing_offers/test_mode', {
+      max_premium_amount: 10000,
+      max_advance_amount: 100000,
+      max_withhold_rate_str: 0.15,
+      is_refill: false,
+      financing_type: 'flex_loan',
+      state,
+      is_youlend: false,
+      is_fixed_term: false,
+      'loan_repayment_details[repayment_interval_duration_days]': 60,
+      'loan_repayment_details[target_payback_weeks]': 42,
+      country: 'US',
+      connected_account,
+    });
+
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: {'Content-Type': 'application/json'},
+    });
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to create test financing offer',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/capital/expire_test_financing/route.ts
+++ b/app/api/capital/expire_test_financing/route.ts
@@ -13,6 +13,13 @@ export async function POST() {
       .filter((o) => o.status === 'delivered')
       .at(0);
 
+    if (offer == undefined) {
+      throw Error(
+        'Unable to find offer with status `delivered` for connected account: ' +
+          connected_account
+      );
+    }
+
     await stripe.rawRequest(
       'POST',
       `/v1/capital/financing_offers/${offer!.id}/expire`,

--- a/app/api/capital/expire_test_financing/route.ts
+++ b/app/api/capital/expire_test_financing/route.ts
@@ -13,7 +13,7 @@ export async function POST() {
       .filter((o) => o.status === 'delivered')
       .at(0);
 
-    if (offer == undefined) {
+    if (offer === undefined) {
       throw Error(
         'Unable to find offer with status `delivered` for connected account: ' +
           connected_account

--- a/app/api/capital/expire_test_financing/route.ts
+++ b/app/api/capital/expire_test_financing/route.ts
@@ -1,0 +1,35 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+
+export async function POST() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    const connected_account = session!.user.stripeAccount.id;
+    const offer = (
+      await stripe.capital.financingOffers.list({connected_account, limit: 1})
+    ).data
+      .filter((o) => o.status === 'delivered')
+      .at(0);
+
+    await stripe.rawRequest(
+      'POST',
+      `/v1/capital/financing_offers/${offer!.id}/expire`,
+      {}
+    );
+
+    return new Response(
+      JSON.stringify({
+        offer,
+      }),
+      {status: 200, headers: {'Content-Type': 'application/json'}}
+    );
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to expire test financing offer',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/capital/fully_repay_test_financing/route.ts
+++ b/app/api/capital/fully_repay_test_financing/route.ts
@@ -1,0 +1,35 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+
+export async function POST() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    const connected_account = session!.user.stripeAccount.id;
+    const offer = (
+      await stripe.capital.financingOffers.list({connected_account, limit: 1})
+    ).data
+      .filter((o) => o.status === 'paid_out')
+      .at(0);
+
+    await stripe.rawRequest(
+      'POST',
+      `/v1/capital/financing_offers/${offer!.id}/fully_repay`,
+      {}
+    );
+
+    return new Response(
+      JSON.stringify({
+        offer,
+      }),
+      {status: 200, headers: {'Content-Type': 'application/json'}}
+    );
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to fully repay test financing offer',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/capital/fully_repay_test_financing/route.ts
+++ b/app/api/capital/fully_repay_test_financing/route.ts
@@ -13,7 +13,7 @@ export async function POST() {
       .filter((o) => o.status === 'paid_out')
       .at(0);
 
-    if (offer == undefined) {
+    if (offer === undefined) {
       throw Error(
         'Unable to find offer with status `paid_out` for connected account: ' +
           connected_account

--- a/app/api/capital/fully_repay_test_financing/route.ts
+++ b/app/api/capital/fully_repay_test_financing/route.ts
@@ -13,6 +13,13 @@ export async function POST() {
       .filter((o) => o.status === 'paid_out')
       .at(0);
 
+    if (offer == undefined) {
+      throw Error(
+        'Unable to find offer with status `paid_out` for connected account: ' +
+          connected_account
+      );
+    }
+
     await stripe.rawRequest(
       'POST',
       `/v1/capital/financing_offers/${offer!.id}/fully_repay`,

--- a/app/api/capital/get_financing_offer/route.ts
+++ b/app/api/capital/get_financing_offer/route.ts
@@ -1,0 +1,27 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    const connected_account = session!.user.stripeAccount.id;
+    const offer = (
+      await stripe.capital.financingOffers.list({connected_account, limit: 1})
+    ).data.at(0);
+
+    return new Response(
+      JSON.stringify({
+        offer,
+      }),
+      {status: 200, headers: {'Content-Type': 'application/json'}}
+    );
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to list financing offers',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/capital/reject_test_financing/route.ts
+++ b/app/api/capital/reject_test_financing/route.ts
@@ -13,6 +13,13 @@ export async function POST() {
       .filter((o) => o.status === 'accepted')
       .at(0);
 
+    if (offer == undefined) {
+      throw Error(
+        'Unable to find offer with status `accepted` for connected account: ' +
+          connected_account
+      );
+    }
+
     await stripe.rawRequest(
       'POST',
       `/v1/capital/financing_offers/${offer!.id}/revoke_v2`,

--- a/app/api/capital/reject_test_financing/route.ts
+++ b/app/api/capital/reject_test_financing/route.ts
@@ -13,7 +13,7 @@ export async function POST() {
       .filter((o) => o.status === 'accepted')
       .at(0);
 
-    if (offer == undefined) {
+    if (offer === undefined) {
       throw Error(
         'Unable to find offer with status `accepted` for connected account: ' +
           connected_account

--- a/app/api/capital/reject_test_financing/route.ts
+++ b/app/api/capital/reject_test_financing/route.ts
@@ -1,0 +1,35 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+
+export async function POST() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    const connected_account = session!.user.stripeAccount.id;
+    const offer = (
+      await stripe.capital.financingOffers.list({connected_account, limit: 1})
+    ).data
+      .filter((o) => o.status === 'accepted')
+      .at(0);
+
+    await stripe.rawRequest(
+      'POST',
+      `/v1/capital/financing_offers/${offer!.id}/revoke_v2`,
+      {}
+    );
+
+    return new Response(
+      JSON.stringify({
+        offer,
+      }),
+      {status: 200, headers: {'Content-Type': 'application/json'}}
+    );
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to reject test financing offer',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/components/ToolsPanel.tsx
+++ b/app/components/ToolsPanel.tsx
@@ -42,6 +42,7 @@ import CreateInterventionsButton from './testdata/CreateInterventionsButton';
 import CreatePayoutsButton from './testdata/CreatePayoutsButton';
 import CreateFinancialCreditButton from './testdata/CreateFinancialCreditButton';
 import CreateCheckoutSessionButton from './testdata/CreateCheckoutSessionButton';
+import ManageFinancing from './testdata/Financing/ManageFinancing';
 
 const ToolsPanel = () => {
   const pathname = usePathname();
@@ -91,6 +92,11 @@ const ToolsPanel = () => {
       description: 'Create a test financial credit',
       href: '/finances',
       component: CreateFinancialCreditButton,
+    },
+    {
+      description: 'Manage Financing',
+      href: '/finances',
+      component: ManageFinancing,
     },
   ];
 

--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -1,0 +1,105 @@
+import {Button} from '@/components/ui/button';
+import {LoaderCircle} from 'lucide-react';
+import React from 'react';
+import {OfferState} from './types';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+import {Form, FormField, FormItem, FormLabel} from '@/components/ui/form';
+import {z} from 'zod';
+import {zodResolver} from '@hookform/resolvers/zod';
+import Stripe from 'stripe';
+import {useForm} from 'react-hook-form';
+import {TransitionFinancingButton} from './TransitionFinancingButton';
+
+const SELECTABLE_OFFER_STATES_ARRAY: Array<
+  Extract<
+    Stripe.Capital.FinancingOfferListParams.Status,
+    'delivered' | 'accepted' | 'rejected' | 'fully_repaid' | 'paid_out'
+  >
+> = ['delivered', 'accepted', 'rejected', 'paid_out', 'fully_repaid'] as const;
+
+type SelectableOfferStates = (typeof SELECTABLE_OFFER_STATES_ARRAY)[0];
+
+export function CreateFlexLoanButton({
+  classes,
+  offerState: existingOfferState,
+  visibleForOfferStates,
+}: Omit<
+  React.ComponentProps<typeof TransitionFinancingButton>,
+  'label' | 'fetchUrl'
+>) {
+  const [buttonLoading, setButtonLoading] = React.useState(false);
+  const [financingState, setFinancingState] =
+    React.useState<SelectableOfferStates>('delivered');
+
+  const form = useForm<{financingStateFieldValue: SelectableOfferStates}>({
+    defaultValues: {financingStateFieldValue: financingState},
+  });
+
+  if (visibleForOfferStates.includes(existingOfferState)) {
+    return (
+      <>
+        <div className="flex items-center text-sm font-bold text-primary">
+          Create Flex Loan
+        </div>
+
+        <Form {...form}>
+          <FormField
+            control={form.control}
+            name="financingStateFieldValue"
+            render={({field}) => (
+              <FormItem
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: 15,
+                  alignItems: 'center',
+                }}
+              >
+                <FormLabel>Offer Status</FormLabel>
+                <Select
+                  {...field}
+                  onValueChange={(val) => setFinancingState(val as any)}
+                >
+                  <SelectTrigger
+                    className="w-[162px] text-xs"
+                    disabled={buttonLoading}
+                  >
+                    <SelectValue className="text-xs" placeholder="Locale">
+                      {financingState}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent className="z-[130] text-xs">
+                    {SELECTABLE_OFFER_STATES_ARRAY.map((offerState, index) => (
+                      <SelectItem value={`${offerState}`} key={index}>
+                        {offerState}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormItem>
+            )}
+          />
+          <TransitionFinancingButton
+            label={'Create'}
+            fetchUrl="/api/capital/create_test_financing"
+            visibleForOfferStates={visibleForOfferStates}
+            offerState={existingOfferState}
+            fetchBody={{
+              offerState: financingState,
+            }}
+            form={form}
+          />
+        </Form>
+      </>
+    );
+  } else {
+    return undefined;
+  }
+}

--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -26,6 +26,12 @@ const SELECTABLE_OFFER_STATES_ARRAY: Array<
 
 type SelectableOfferStates = (typeof SELECTABLE_OFFER_STATES_ARRAY)[0];
 
+const enumValueToSentenceCase = (value: String) => {
+  const words = value.split('_');
+  words[0] = words[0].at(0)?.toUpperCase() + words[0].substring(1);
+  return words.join(' ');
+};
+
 export function CreateFlexLoanButton({
   classes,
   offerState: existingOfferState,
@@ -46,7 +52,7 @@ export function CreateFlexLoanButton({
     return (
       <>
         <div className="flex items-center text-sm font-bold text-primary">
-          Create Flex Loan
+          Create flex loan
         </div>
 
         <Form {...form}>
@@ -62,7 +68,7 @@ export function CreateFlexLoanButton({
                   alignItems: 'center',
                 }}
               >
-                <FormLabel>Offer Status</FormLabel>
+                <FormLabel>Offer state</FormLabel>
                 <Select
                   {...field}
                   onValueChange={(val) => setFinancingState(val as any)}
@@ -72,13 +78,13 @@ export function CreateFlexLoanButton({
                     disabled={buttonLoading}
                   >
                     <SelectValue className="text-xs" placeholder="Locale">
-                      {financingState}
+                      {enumValueToSentenceCase(financingState)}
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent className="z-[130] text-xs">
                     {SELECTABLE_OFFER_STATES_ARRAY.map((offerState, index) => (
                       <SelectItem value={`${offerState}`} key={index}>
-                        {offerState}
+                        {enumValueToSentenceCase(offerState)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -74,14 +74,14 @@ export function CreateFlexLoanButton({
                   onValueChange={(val) => setFinancingState(val as any)}
                 >
                   <SelectTrigger
-                    className="w-[162px] text-xs"
+                    className="w-[162px] text-sm"
                     disabled={buttonLoading}
                   >
-                    <SelectValue className="text-xs" placeholder="Locale">
+                    <SelectValue className="text-sm" placeholder="Locale">
                       {enumValueToSentenceCase(financingState)}
                     </SelectValue>
                   </SelectTrigger>
-                  <SelectContent className="z-[130] text-xs">
+                  <SelectContent className="z-[130] text-sm">
                     {SELECTABLE_OFFER_STATES_ARRAY.map((offerState, index) => (
                       <SelectItem value={`${offerState}`} key={index}>
                         {enumValueToSentenceCase(offerState)}

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -59,27 +59,27 @@ export default function ManageFinancing({classes}: {classes?: string}) {
           />
 
           <TransitionFinancingButton
-            label={'Expire Financing Offer'}
+            label={'Expire financing offer'}
             fetchUrl="/api/capital/expire_test_financing"
             visibleForOfferStates={['delivered']}
             offerState={offerState}
           />
 
           <TransitionFinancingButton
-            label={'Approve Financing Application'}
+            label={'Approve financing application'}
             fetchUrl="/api/capital/approve_test_financing"
             visibleForOfferStates={['accepted']}
             offerState={offerState}
           />
           <TransitionFinancingButton
-            label={'Reject Financing Application'}
+            label={'Reject financing application'}
             fetchUrl="/api/capital/reject_test_financing"
             visibleForOfferStates={['accepted']}
             offerState={offerState}
           />
 
           <TransitionFinancingButton
-            label={'Fully repay Financing'}
+            label={'Fully repay financing'}
             fetchUrl="/api/capital/fully_repay_test_financing"
             visibleForOfferStates={['paid_out']}
             offerState={offerState}

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -38,11 +38,10 @@ export default function ManageFinancing({classes}: {classes?: string}) {
     <>
       <div className="text-md my-4 flex items-center gap-x-2 font-bold text-primary">
         Capital
-        {loading && !offerState && (
-          <LoaderCircle className="ml-2 animate-spin items-center" size={20} />
-        )}
       </div>
-
+      {loading && !offerState && (
+        <LoaderCircle className="ml-2 animate-spin items-center" size={20} />
+      )}
       {!loading && offerState && (
         <>
           <CreateFlexLoanButton

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {OfferState} from './types';
+import {CreateFlexLoanButton} from './CreateFlexLoanButton';
+import {LoaderCircle} from 'lucide-react';
+import {TransitionFinancingButton} from './TransitionFinancingButton';
+
+export default function ManageFinancing({classes}: {classes?: string}) {
+  const [loading, setLoading] = React.useState(true);
+  const [offerState, setOfferState] = React.useState<OfferState | undefined>(
+    undefined
+  );
+
+  const response = React.useCallback(() => {
+    if (offerState === undefined) {
+      fetch('/api/capital/get_financing_offer', {
+        method: 'get',
+      })
+        .then(async (res) => {
+          const status = (await res.json()).offer?.status;
+          setOfferState(status || 'no_offer');
+        })
+        .catch(async (err) => {
+          // Handle errors on the client side here
+          console.warn('An error occurred: ', err);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
+  }, [offerState]);
+  response();
+
+  if (!offerState && !loading) {
+    return undefined;
+  }
+
+  return (
+    <>
+      <div className="text-md my-4 flex items-center gap-x-2 font-bold text-primary">
+        Capital
+        {loading && !offerState && (
+          <LoaderCircle className="ml-2 animate-spin items-center" size={20} />
+        )}
+      </div>
+
+      {!loading && offerState && (
+        <>
+          <CreateFlexLoanButton
+            classes={classes}
+            offerState={offerState}
+            visibleForOfferStates={[
+              'canceled',
+              'completed',
+              'expired',
+              'fully_repaid',
+              'rejected',
+              'revoked',
+              'no_offer',
+            ]}
+          />
+
+          <TransitionFinancingButton
+            label={'Expire Financing Offer'}
+            fetchUrl="/api/capital/expire_test_financing"
+            visibleForOfferStates={['delivered']}
+            offerState={offerState}
+          />
+
+          <TransitionFinancingButton
+            label={'Approve Financing Application'}
+            fetchUrl="/api/capital/approve_test_financing"
+            visibleForOfferStates={['accepted']}
+            offerState={offerState}
+          />
+          <TransitionFinancingButton
+            label={'Reject Financing Application'}
+            fetchUrl="/api/capital/reject_test_financing"
+            visibleForOfferStates={['accepted']}
+            offerState={offerState}
+          />
+
+          <TransitionFinancingButton
+            label={'Fully repay Financing'}
+            fetchUrl="/api/capital/fully_repay_test_financing"
+            visibleForOfferStates={['paid_out']}
+            offerState={offerState}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/app/components/testdata/Financing/TransitionFinancingButton.tsx
+++ b/app/components/testdata/Financing/TransitionFinancingButton.tsx
@@ -52,7 +52,7 @@ export function TransitionFinancingButton({
     return (
       <Button
         className={`${classes || 'border'}`}
-        variant="default"
+        variant="secondary"
         onClick={form ? form.handleSubmit(onClick) : onClick}
         disabled={buttonLoading}
         size="sm"

--- a/app/components/testdata/Financing/TransitionFinancingButton.tsx
+++ b/app/components/testdata/Financing/TransitionFinancingButton.tsx
@@ -1,0 +1,69 @@
+import {Button} from '@/components/ui/button';
+import {LoaderCircle} from 'lucide-react';
+import React from 'react';
+import Stripe from 'stripe';
+import {OfferState} from './types';
+import {UseFormReturn} from 'react-hook-form';
+
+const OFFER_STATES_TO_DISPLAY_ON: OfferState[] = ['accepted'];
+
+export function TransitionFinancingButton({
+  classes,
+  offerState,
+  label,
+  fetchUrl,
+  visibleForOfferStates,
+  fetchMethod: method = 'POST',
+  fetchBody = {},
+  form,
+}: {
+  offerState: OfferState;
+  label: string;
+  fetchUrl: string;
+  visibleForOfferStates: OfferState[];
+  classes?: string;
+  fetchMethod?: string;
+  fetchBody?: {};
+  form?: UseFormReturn<any>;
+}) {
+  const [buttonLoading, setButtonLoading] = React.useState(false);
+  const onClick = async () => {
+    setButtonLoading(true);
+    try {
+      const res = await fetch(fetchUrl, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(fetchBody),
+      });
+      setButtonLoading(false);
+
+      if (res.ok) {
+        window.location.reload();
+      }
+    } catch (e) {
+      console.log(`Error attempting to \`${label}\`: `, e);
+      setButtonLoading(false);
+    }
+  };
+
+  if (visibleForOfferStates.includes(offerState)) {
+    return (
+      <Button
+        className={`${classes || 'border'}`}
+        variant="default"
+        onClick={form ? form.handleSubmit(onClick) : onClick}
+        disabled={buttonLoading}
+        size="sm"
+      >
+        {label}
+        {buttonLoading && (
+          <LoaderCircle className="ml-2 animate-spin items-center" size={20} />
+        )}
+      </Button>
+    );
+  } else {
+    return undefined;
+  }
+}

--- a/app/components/testdata/Financing/types.ts
+++ b/app/components/testdata/Financing/types.ts
@@ -1,0 +1,5 @@
+import Stripe from 'stripe';
+
+export type OfferState =
+  | Stripe.Capital.FinancingOfferListParams.Status
+  | 'no_offer';


### PR DESCRIPTION
This adds buttons to the tool panel:

- Create a Flex Loan Offer in a certain state
- Expire a delivered offer
- Approve/Reject an accepted offer
- Fully repay a paid out offer

The buttons are shown when the connected account has a financing offer in a certain state or does not have a financing state at all.

Screen Recording:
https://github.com/user-attachments/assets/83ce911d-8d2d-4f10-a51b-9be2d5d76620

[Edit]
Screen Recording as of 33febfd
https://github.com/user-attachments/assets/ff0bfccf-b4d0-436a-89e6-0c95d7b99655
