### PR TITLE
UX changes to Capital helpers in Tools Panels

### DIFF
--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -82,7 +82,7 @@ export function CreateFlexLoanButton({
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent className="z-[130] text-xs">
-                    {SELECTABLE_OFFER_STATES_ARRAY.map((offerState, index) => (
+                    {SELECTABLE_OFFER_STATES_ARRAY.map((offerState) => (
                       <SelectItem
                         value={offerState}
                         key={offerState}

--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -84,8 +84,8 @@ export function CreateFlexLoanButton({
                   <SelectContent className="z-[130] text-xs">
                     {SELECTABLE_OFFER_STATES_ARRAY.map((offerState, index) => (
                       <SelectItem
-                        value={`${offerState}`}
-                        key={index}
+                        value={offerState}
+                        key={offerState}
                         className="z-[130] text-xs"
                       >
                         {enumValueToSentenceCase(offerState)}

--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -64,24 +64,24 @@ export function CreateFlexLoanButton({
                 style={{
                   display: 'flex',
                   flexWrap: 'wrap',
-                  gap: 15,
                   alignItems: 'center',
+                  flexDirection: 'row',
                 }}
               >
-                <FormLabel>Offer state</FormLabel>
+                <FormLabel style={{flexGrow: 1}}>Offer state</FormLabel>
                 <Select
                   {...field}
                   onValueChange={(val) => setFinancingState(val as any)}
                 >
                   <SelectTrigger
-                    className="w-[162px] text-sm"
+                    className="w-[162px] text-xs"
                     disabled={buttonLoading}
                   >
-                    <SelectValue className="text-sm" placeholder="Locale">
+                    <SelectValue className="text-xs" placeholder="Locale">
                       {enumValueToSentenceCase(financingState)}
                     </SelectValue>
                   </SelectTrigger>
-                  <SelectContent className="z-[130] text-sm">
+                  <SelectContent className="z-[130] text-xs">
                     {SELECTABLE_OFFER_STATES_ARRAY.map((offerState, index) => (
                       <SelectItem value={`${offerState}`} key={index}>
                         {enumValueToSentenceCase(offerState)}

--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -83,7 +83,11 @@ export function CreateFlexLoanButton({
                   </SelectTrigger>
                   <SelectContent className="z-[130] text-xs">
                     {SELECTABLE_OFFER_STATES_ARRAY.map((offerState, index) => (
-                      <SelectItem value={`${offerState}`} key={index}>
+                      <SelectItem
+                        value={`${offerState}`}
+                        key={index}
+                        className="z-[130] text-xs"
+                      >
                         {enumValueToSentenceCase(offerState)}
                       </SelectItem>
                     ))}

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -36,12 +36,6 @@ export default function ManageFinancing({classes}: {classes?: string}) {
 
   return (
     <>
-      <div className="text-md my-4 flex items-center gap-x-2 font-bold text-primary">
-        Capital
-      </div>
-      {loading && !offerState && (
-        <LoaderCircle className="ml-2 animate-spin items-center" size={20} />
-      )}
       {!loading && offerState && (
         <>
           <CreateFlexLoanButton


### PR DESCRIPTION
- Right align select componet
- Make select field `text-xs`

- Remove `Capital` header in Tools Panel


<img width="315" alt="image" src="https://github.com/user-attachments/assets/f6a3bd97-207d-4b2a-b644-a7cc65d69380" />
