### PR TITLE
Increase Financing offer size to show slider and fix dropdown bug

### DIFF
--- a/app/api/capital/create_test_financing/route.ts
+++ b/app/api/capital/create_test_financing/route.ts
@@ -12,8 +12,8 @@ export async function POST(req: NextRequest) {
     const state = (await req.json())['offerState'] || 'delivered';
 
     await stripe.rawRequest('POST', '/v1/capital/financing_offers/test_mode', {
-      max_premium_amount: 10000,
-      max_advance_amount: 100000,
+      max_premium_amount: 2000_00,
+      max_advance_amount: 100000_00,
       max_withhold_rate_str: 0.15,
       is_refill: false,
       financing_type: 'flex_loan',

--- a/app/components/testdata/Financing/CreateFlexLoanButton.tsx
+++ b/app/components/testdata/Financing/CreateFlexLoanButton.tsx
@@ -44,9 +44,7 @@ export function CreateFlexLoanButton({
   const [financingState, setFinancingState] =
     React.useState<SelectableOfferStates>('delivered');
 
-  const form = useForm<{financingStateFieldValue: SelectableOfferStates}>({
-    defaultValues: {financingStateFieldValue: financingState},
-  });
+  const form = useForm<{financingStateFieldValue: SelectableOfferStates}>({});
 
   if (visibleForOfferStates.includes(existingOfferState)) {
     return (
@@ -72,12 +70,13 @@ export function CreateFlexLoanButton({
                 <Select
                   {...field}
                   onValueChange={(val) => setFinancingState(val as any)}
+                  defaultValue={financingState}
                 >
                   <SelectTrigger
                     className="w-[162px] text-xs"
                     disabled={buttonLoading}
                   >
-                    <SelectValue className="text-xs" placeholder="Locale">
+                    <SelectValue className="text-xs">
                       {enumValueToSentenceCase(financingState)}
                     </SelectValue>
                   </SelectTrigger>

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -57,6 +57,7 @@ export default function ManageFinancing({classes}: {classes?: string}) {
             fetchUrl="/api/capital/expire_test_financing"
             visibleForOfferStates={['delivered']}
             offerState={offerState}
+            classes={classes}
           />
 
           <TransitionFinancingButton
@@ -64,12 +65,14 @@ export default function ManageFinancing({classes}: {classes?: string}) {
             fetchUrl="/api/capital/approve_test_financing"
             visibleForOfferStates={['accepted']}
             offerState={offerState}
+            classes={classes}
           />
           <TransitionFinancingButton
             label={'Reject financing application'}
             fetchUrl="/api/capital/reject_test_financing"
             visibleForOfferStates={['accepted']}
             offerState={offerState}
+            classes={classes}
           />
 
           <TransitionFinancingButton
@@ -77,6 +80,7 @@ export default function ManageFinancing({classes}: {classes?: string}) {
             fetchUrl="/api/capital/fully_repay_test_financing"
             visibleForOfferStates={['paid_out']}
             offerState={offerState}
+            classes={classes}
           />
         </>
       )}


### PR DESCRIPTION
- Increase test financing offer size so that the offer application shows a slider. In the future, we might make this a configurable option in the frontend
<img width="509" alt="image" src="https://github.com/user-attachments/assets/1fc84415-f794-4056-9a1c-4c039b87e6b9" />

- Fix dropdown bug in the `Create flex loan` helper where you could not select the default option `Delivered` after selecting another option. Setting the Radix form's default value caused some contention and removing it fixed it. 