### PR TITLE
Avoid flicker by using a specific redirect message instead of the onboarding component

### DIFF
--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -5,10 +5,20 @@ import EmbeddedComponentContainer from '@/app/components/EmbeddedComponentContai
 import React from 'react';
 
 export default function Onboarding() {
+  const [hasCompletedOnboarding, setHasCompletedOnboarding] =
+    React.useState(false);
+
+  if (hasCompletedOnboarding) {
+    return <div>Onboarding finished! Redirecting to dashboard...</div>;
+  }
+
   return (
     <EmbeddedComponentContainer componentName="AccountOnboarding">
       <ConnectAccountOnboarding
         onExit={() => {
+          // Since redirecting takes some time, we set the state first to hide the onboarding component to avoid showing the default "success" screen
+          setHasCompletedOnboarding(true);
+
           window.location.href = '/home?shownux=true';
         }}
       />


### PR DESCRIPTION
This PR removes the onboarding component success mesage by replacing it with a specific redirect message.

