### PR TITLE
Add Capital Financing API testmode routes for line of credit demo

### DIFF
--- a/app/api/capital/create_line_of_credit/route.ts
+++ b/app/api/capital/create_line_of_credit/route.ts
@@ -1,0 +1,44 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+import {NextRequest} from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session) {
+      return new Response('The current route requires authentication', {
+        status: 403,
+      });
+    }
+
+    const connected_account = session.user.stripeAccountId;
+
+    const state = (await req.json())['offerState'] || 'delivered';
+
+    await stripe.rawRequest(
+      'POST',
+      '/v1/test_helpers/capital/line_of_credit/create_or_refresh',
+      {
+        connected_account: connected_account,
+        country: 'US',
+        max_advance_amount: 100000_00,
+        max_premium_amount: 2000_00,
+        max_withhold_rate_str: '0.15',
+        accepted_advance_amount: 5000_00,
+      }
+    );
+
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: {'Content-Type': 'application/json'},
+    });
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to create test financing offer',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/capital/create_side_by_side_offer/route.ts
+++ b/app/api/capital/create_side_by_side_offer/route.ts
@@ -1,0 +1,54 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+import {NextRequest} from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session) {
+      return new Response('The current route requires authentication', {
+        status: 403,
+      });
+    }
+
+    const connected_account = session.user.stripeAccountId;
+
+    await stripe.rawRequest('POST', '/v1/capital/financing_offers/test_mode', {
+      max_premium_amount: 10000_00,
+      max_advance_amount: 100000_00,
+      max_withhold_rate_str: 0.15,
+      is_refill: false,
+      financing_type: 'flex_loan',
+      state: 'delivered',
+      is_youlend: false,
+      is_fixed_term: false,
+      'loan_repayment_details[repayment_interval_duration_days]': 60,
+      'loan_repayment_details[target_payback_weeks]': 42,
+      country: 'US',
+      connected_account,
+      additional_financing_offers: [
+        {
+          financing_type: 'flex_loan',
+          max_premium_amount: 1000_00,
+          max_advance_amount: 100000_00,
+          max_withhold_rate_str: 0.15,
+          multi_draw_details: {multi_draw_offer_type: 'line'},
+          is_fixed_term: true,
+        },
+      ],
+    });
+
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: {'Content-Type': 'application/json'},
+    });
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to create test financing offer',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}

--- a/app/api/capital/get_line_of_credit_summary/route.ts
+++ b/app/api/capital/get_line_of_credit_summary/route.ts
@@ -1,0 +1,61 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session) {
+      return new Response('The current route requires authentication', {
+        status: 403,
+      });
+    }
+
+    const connected_account = session.user.stripeAccountId;
+
+    return await stripe.capital.financingSummary
+      .retrieve(
+        {},
+        {
+          apiVersion: '2026-03-25.dahlia; capital_line_of_credit_preview=v1',
+          stripeAccount: connected_account,
+        }
+      )
+      .then((summary) => {
+        return new Response(JSON.stringify(summary), {
+          status: 200,
+          headers: {'Content-Type': 'application/json'},
+        });
+      })
+      .catch((reason) => {
+        const message = reason?.['raw']?.['message'];
+        if (
+          message?.includes(
+            'You do not have permission to pass this beta header'
+          )
+        ) {
+          return new Response(
+            JSON.stringify({
+              reason: 'You do not have permission to pass this beta header',
+            }),
+            {
+              status: 400,
+              headers: {'Content-Type': 'application/json'},
+            }
+          );
+        } else {
+          return new Response(JSON.stringify(reason), {
+            status: 500,
+            headers: {'Content-Type': 'application/json'},
+          });
+        }
+      });
+  } catch (error: any) {
+    console.error(
+      'An error occurred when calling the Stripe API to retrieve financing summary',
+      error
+    );
+    return new Response(error.message, {status: 500});
+  }
+}


### PR DESCRIPTION
This PR introduces three new endpoints that will be used to power test helpers in the ToolsPanel for the new Line of Credit feature. 

- Creating a line of credit
- Creating a side by side flex loan/line of credit offer
- Get an active line if exists