### PR TITLE
Create Capital Account Links Endpoint and Frontend

### DIFF
--- a/app/api/account_link/route.ts
+++ b/app/api/account_link/route.ts
@@ -18,9 +18,9 @@ export async function GET(req: NextRequest) {
       });
     }
 
-    const args = req.nextUrl.searchParams;
-    const linkType = args.get('type') || 'capital_financing_offer';
-    shouldRedirect = args.get('shouldRedirect') === 'true';
+    const searchParams = new URLSearchParams(req.nextUrl.search);
+    const linkType = searchParams.get('type');
+    shouldRedirect = searchParams.get('shouldRedirect') === 'true';
 
     const baseUrl = req.nextUrl.origin;
 
@@ -29,15 +29,15 @@ export async function GET(req: NextRequest) {
       type: linkType as Parameters<
         typeof stripe.accountLinks.create
       >[0]['type'],
-      return_url: `${baseUrl}/api/capital/account_link?shouldRedirect=true&type=capital_financing_offer`,
-      refresh_url: `${baseUrl}/api/capital/account_link?shouldRedirect=true&type=capital_financing_offer`,
+      return_url: `${baseUrl}/api/account_link?shouldRedirect=true&type=${linkType}`,
+      refresh_url: `${baseUrl}/api/account_link?shouldRedirect=true&type=${linkType}`,
     });
   } catch (error: any) {
     console.error('Error creating account link: ', error);
     return new Response(error.message, {status: 500});
   }
 
-  // Returns status code 307/303 to the caller
+  // Returns status code 307/303 to the caller, this needs to be outside of the try/catch block since nextjs throws an error it later catches
   if (shouldRedirect) {
     redirect(link?.url, RedirectType.push);
   } else {

--- a/app/api/account_link/route.ts
+++ b/app/api/account_link/route.ts
@@ -26,9 +26,12 @@ export async function GET(req: NextRequest) {
 
     if (!linkType) {
       console.error('Account Link type is required');
-      return new Response('Account Link type is required', {
-        status: 400,
-      });
+      return new Response(
+        'app/api/account_link/route.ts Link type is required',
+        {
+          status: 400,
+        }
+      );
     }
 
 

--- a/app/api/account_link/route.ts
+++ b/app/api/account_link/route.ts
@@ -34,7 +34,6 @@ export async function GET(req: NextRequest) {
       );
     }
 
-
     link = await stripe.accountLinks.create({
       account: session?.user?.stripeAccountId,
       type: linkType as Parameters<

--- a/app/api/account_link/route.ts
+++ b/app/api/account_link/route.ts
@@ -8,6 +8,8 @@ import {Stripe} from 'stripe';
 export async function GET(req: NextRequest) {
   let link = null;
   let shouldRedirect = false;
+  const baseUrl = req.nextUrl.origin;
+
   try {
     const session = await getServerSession(authOptions);
 
@@ -22,7 +24,13 @@ export async function GET(req: NextRequest) {
     const linkType = searchParams.get('type');
     shouldRedirect = searchParams.get('shouldRedirect') === 'true';
 
-    const baseUrl = req.nextUrl.origin;
+    if (!linkType) {
+      console.error('Account Link type is required');
+      return new Response('Account Link type is required', {
+        status: 400,
+      });
+    }
+
 
     link = await stripe.accountLinks.create({
       account: session?.user?.stripeAccountId,
@@ -39,7 +47,7 @@ export async function GET(req: NextRequest) {
 
   // Returns status code 307/303 to the caller, this needs to be outside of the try/catch block since nextjs throws an error it later catches
   if (shouldRedirect) {
-    redirect(link?.url, RedirectType.push);
+    redirect(link?.url || baseUrl, RedirectType.push);
   } else {
     return new Response(JSON.stringify({url: link?.url}), {status: 200});
   }

--- a/app/api/capital/account_link/route.ts
+++ b/app/api/capital/account_link/route.ts
@@ -1,0 +1,46 @@
+import {getServerSession} from 'next-auth/next';
+import {authOptions} from '@/lib/auth';
+import {stripe} from '@/lib/stripe';
+import {NextRequest} from 'next/server';
+import {redirect, RedirectType} from 'next/navigation';
+import {Stripe} from 'stripe';
+
+export async function GET(req: NextRequest) {
+  let link = null;
+  let shouldRedirect = false;
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.stripeAccountId) {
+      console.error('No connected account found for user');
+      return new Response('No connected account found for user', {
+        status: 400,
+      });
+    }
+
+    const args = req.nextUrl.searchParams;
+    const linkType = args.get('type') || 'capital_financing_offer';
+    shouldRedirect = args.get('shouldRedirect') === 'true';
+
+    const baseUrl = req.nextUrl.origin;
+
+    link = await stripe.accountLinks.create({
+      account: session?.user?.stripeAccountId,
+      type: linkType as Parameters<
+        typeof stripe.accountLinks.create
+      >[0]['type'],
+      return_url: `${baseUrl}/api/capital/account_link?shouldRedirect=true&type=capital_financing_offer`,
+      refresh_url: `${baseUrl}/api/capital/account_link?shouldRedirect=true&type=capital_financing_offer`,
+    });
+  } catch (error: any) {
+    console.error('Error creating account link: ', error);
+    return new Response(error.message, {status: 500});
+  }
+
+  // Returns status code 307/303 to the caller
+  if (shouldRedirect) {
+    redirect(link?.url, RedirectType.push);
+  } else {
+    return new Response(JSON.stringify({url: link?.url}), {status: 200});
+  }
+}

--- a/app/components/testdata/Financing/CapitalAccountLinkButton.tsx
+++ b/app/components/testdata/Financing/CapitalAccountLinkButton.tsx
@@ -24,8 +24,6 @@ export function CapitalAccountLinkButton({
       });
 
       const accountLink = (await res.json()).url;
-      setButtonLoading(false);
-
       window.open(accountLink, '_blank', 'noopener,noreferrer');
     } catch (e) {
       console.log('Error attempting to create capital account link: ', e);

--- a/app/components/testdata/Financing/CapitalAccountLinkButton.tsx
+++ b/app/components/testdata/Financing/CapitalAccountLinkButton.tsx
@@ -14,7 +14,7 @@ export function CapitalAccountLinkButton({
   const onClick = async () => {
     setButtonLoading(true);
     try {
-      const url = new URL('/api/capital/account_link', window.location.origin);
+      const url = new URL('/api/account_link', window.location.origin);
       url.searchParams.set('shouldRedirect', 'false');
 
       url.searchParams.set('type', type);

--- a/app/components/testdata/Financing/CapitalAccountLinkButton.tsx
+++ b/app/components/testdata/Financing/CapitalAccountLinkButton.tsx
@@ -1,0 +1,51 @@
+import {Button} from '@/components/ui/button';
+import {ExternalLinkIcon} from '@radix-ui/react-icons';
+import {LoaderCircle} from 'lucide-react';
+import React from 'react';
+import {UseFormReturn} from 'react-hook-form';
+import {OfferState} from './types';
+
+export function CapitalAccountLinkButton({
+  type,
+}: {
+  type: 'capital_financing_offer' | 'capital_financing_reporting';
+}) {
+  const [buttonLoading, setButtonLoading] = React.useState(false);
+  const onClick = async () => {
+    setButtonLoading(true);
+    try {
+      const url = new URL('/api/capital/account_link', window.location.origin);
+      url.searchParams.set('shouldRedirect', 'false');
+
+      url.searchParams.set('type', type);
+
+      const res = await fetch(url, {
+        method: 'GET',
+      });
+
+      const accountLink = (await res.json()).url;
+      setButtonLoading(false);
+
+      window.open(accountLink, '_blank', 'noopener,noreferrer');
+    } catch (e) {
+      console.log('Error attempting to create capital account link: ', e);
+    } finally {
+      setButtonLoading(false);
+    }
+  };
+
+  return (
+    <Button onClick={onClick} className="border text-xs" variant="secondary">
+      {!buttonLoading && (
+        <div className="flex items-center gap-x-1">
+          {type === 'capital_financing_offer' ? 'Offer ' : 'Reporting '}
+          dashboard
+          <ExternalLinkIcon className="h-3 w-3" />
+        </div>
+      )}
+      {buttonLoading && (
+        <LoaderCircle className="ml-2 animate-spin items-center" size={20} />
+      )}
+    </Button>
+  );
+}

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -25,6 +25,7 @@ import {
 import {TransitionFinancingButton} from './TransitionFinancingButton';
 import {Link} from '@/components/ui/link';
 import {ExternalLinkIcon} from '@radix-ui/react-icons';
+import {CapitalAccountLinkButton} from './CapitalAccountLinkButton';
 
 export default function ManageFinancing({classes}: {classes?: string}) {
   const [loading, setLoading] = React.useState(true);
@@ -125,162 +126,188 @@ export default function ManageFinancing({classes}: {classes?: string}) {
   const supportedProductTypes = FINANCING_OFFER_PRODUCT_TYPES_ARRAY;
 
   return (
-    <Form {...form}>
-      {formType === 'create' && (
-        <>
-          <ManageFinancingOfferFormField
-            name="financingOfferType"
-            label={
-              <div>
-                <Link
-                  href="https://docs.stripe.com/capital/how-capital-for-platforms-works#types-of-financing-offers"
-                  target="_blank"
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: '2px',
-                  }}
-                >
-                  {'Product Type'}
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </Link>
-              </div>
-            }
-            form={form}
-            loading={loading}
-            render={({field}) => {
-              return (
-                <Select
-                  {...field}
-                  onValueChange={(val) => {
-                    const newFinancingOfferType =
-                      val as FinancingOfferProductType;
-                    form.setValue('financingOfferType', newFinancingOfferType);
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <div className="gap-2 text-sm font-bold">Create financing offer</div>
+        <Form {...form}>
+          {formType === 'create' && (
+            <>
+              <ManageFinancingOfferFormField
+                name="financingOfferType"
+                label={
+                  <div>
+                    <Link
+                      href="https://docs.stripe.com/capital/how-capital-for-platforms-works#types-of-financing-offers"
+                      target="_blank"
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: '2px',
+                      }}
+                    >
+                      {'Product Type'}
+                      <ExternalLinkIcon className="h-3 w-3" />
+                    </Link>
+                  </div>
+                }
+                form={form}
+                loading={loading}
+                render={({field}) => {
+                  return (
+                    <Select
+                      {...field}
+                      onValueChange={(val) => {
+                        const newFinancingOfferType =
+                          val as FinancingOfferProductType;
+                        form.setValue(
+                          'financingOfferType',
+                          newFinancingOfferType
+                        );
 
-                    const statesForProductType =
-                      STATES_FOR_PRODUCT_TYPE[newFinancingOfferType];
+                        const statesForProductType =
+                          STATES_FOR_PRODUCT_TYPE[newFinancingOfferType];
 
-                    // If the product type changes and the offer state is not valid for the new product type, set the offer state to the first valid state for the new product type
-                    if (!statesForProductType.includes(formOfferState)) {
-                      form.setValue('offerState', statesForProductType[0]);
-                    }
-                  }}
-                  defaultValue={field.value}
-                >
-                  <SelectTrigger
-                    className="w-[120px] text-xs"
-                    disabled={loading}
-                  >
-                    <SelectValue className="text-xs">
-                      {enumValueToSentenceCase(field.value)}
-                    </SelectValue>
-                  </SelectTrigger>
-
-                  <SelectContent className="z-[100] text-xs">
-                    {supportedProductTypes.map((productType) => (
-                      <SelectItem
-                        value={productType}
-                        key={productType}
-                        className="z-[130] text-xs"
-                        disabled={
-                          !hasLineOfCreditFeature &&
-                          LINE_OF_CREDIT_PRODUCT_TYPES_ARRAY.includes(
-                            productType as any
-                          )
+                        // If the product type changes and the offer state is not valid for the new product type, set the offer state to the first valid state for the new product type
+                        if (!statesForProductType.includes(formOfferState)) {
+                          form.setValue('offerState', statesForProductType[0]);
                         }
+                      }}
+                      defaultValue={field.value}
+                    >
+                      <SelectTrigger
+                        className="w-[120px] text-xs"
+                        disabled={loading}
                       >
-                        {enumValueToSentenceCase(productType)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              );
-            }}
-          />
-          <ManageFinancingOfferFormField
-            name="offerState"
-            label="Offer State"
-            form={form}
-            loading={loading}
-            render={({field}) => {
-              return (
-                <Select
-                  {...field}
-                  onValueChange={(val) =>
-                    form.setValue('offerState', val as OfferState)
-                  }
-                  defaultValue={field.value}
-                >
-                  <SelectTrigger
-                    className="w-[120px] text-xs"
-                    disabled={loading}
-                  >
-                    <SelectValue className="text-xs">
-                      {enumValueToSentenceCase(field.value)}
-                    </SelectValue>
-                  </SelectTrigger>
+                        <SelectValue className="text-xs">
+                          {enumValueToSentenceCase(field.value)}
+                        </SelectValue>
+                      </SelectTrigger>
 
-                  <SelectContent className="z-[100] text-xs">
-                    {STATES_FOR_PRODUCT_TYPE[
-                      form.watch('financingOfferType')
-                    ].map((productType) => (
-                      <SelectItem
-                        value={productType}
-                        key={productType}
-                        className="z-[100] text-xs"
+                      <SelectContent className="z-[100] text-xs">
+                        {supportedProductTypes.map((productType) => (
+                          <SelectItem
+                            value={productType}
+                            key={productType}
+                            className="z-[130] text-xs"
+                            disabled={
+                              !hasLineOfCreditFeature &&
+                              LINE_OF_CREDIT_PRODUCT_TYPES_ARRAY.includes(
+                                productType as any
+                              )
+                            }
+                          >
+                            {enumValueToSentenceCase(productType)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  );
+                }}
+              />
+              <ManageFinancingOfferFormField
+                name="offerState"
+                label="Offer State"
+                form={form}
+                loading={loading}
+                render={({field}) => {
+                  return (
+                    <Select
+                      {...field}
+                      onValueChange={(val) =>
+                        form.setValue('offerState', val as OfferState)
+                      }
+                      defaultValue={field.value}
+                    >
+                      <SelectTrigger
+                        className="w-[120px] text-xs"
+                        disabled={loading}
                       >
-                        {enumValueToSentenceCase(productType)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              );
-            }}
-          />
+                        <SelectValue className="text-xs">
+                          {enumValueToSentenceCase(field.value)}
+                        </SelectValue>
+                      </SelectTrigger>
 
-          <TransitionFinancingButton
-            label={'Create'}
-            fetchUrl={createUrl}
-            fetchBody={{
-              offerState: form.watch('offerState'),
-            }}
-            form={form}
-          />
-        </>
-      )}
-      {formType === 'expire' && (
-        <TransitionFinancingButton
-          label={'Expire offer'}
-          fetchUrl="/api/capital/expire_test_financing"
-          form={form}
-        />
-      )}
+                      <SelectContent className="z-[100] text-xs">
+                        {STATES_FOR_PRODUCT_TYPE[
+                          form.watch('financingOfferType')
+                        ].map((productType) => (
+                          <SelectItem
+                            value={productType}
+                            key={productType}
+                            className="z-[100] text-xs"
+                          >
+                            {enumValueToSentenceCase(productType)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  );
+                }}
+              />
 
-      {formType === 'approve_reject' && (
-        <>
-          <TransitionFinancingButton
-            label={'Approve financing application'}
-            fetchUrl="/api/capital/approve_test_financing"
-            classes={classes}
-          />
-          <TransitionFinancingButton
-            label={'Reject financing application'}
-            fetchUrl="/api/capital/reject_test_financing"
-            classes={classes}
-            form={form}
-          />
-        </>
-      )}
+              <TransitionFinancingButton
+                label={'Create'}
+                fetchUrl={createUrl}
+                fetchBody={{
+                  offerState: form.watch('offerState'),
+                }}
+                form={form}
+              />
+            </>
+          )}
+          {formType === 'expire' && (
+            <TransitionFinancingButton
+              label={'Expire offer'}
+              fetchUrl="/api/capital/expire_test_financing"
+              form={form}
+            />
+          )}
 
-      {formType === 'fully_repay' && (
-        <TransitionFinancingButton
-          label={'Fully repay financing'}
-          fetchUrl="/api/capital/fully_repay_test_financing"
-          classes={classes}
-          form={form}
-        />
-      )}
-    </Form>
+          {formType === 'approve_reject' && (
+            <>
+              <TransitionFinancingButton
+                label={'Approve financing application'}
+                fetchUrl="/api/capital/approve_test_financing"
+                classes={classes}
+              />
+              <TransitionFinancingButton
+                label={'Reject financing application'}
+                fetchUrl="/api/capital/reject_test_financing"
+                classes={classes}
+                form={form}
+              />
+            </>
+          )}
+
+          {formType === 'fully_repay' && (
+            <TransitionFinancingButton
+              label={'Fully repay financing'}
+              fetchUrl="/api/capital/fully_repay_test_financing"
+              classes={classes}
+              form={form}
+            />
+          )}
+        </Form>
+      </div>
+      <div className="flex flex-col gap-4">
+        <div className="gap-2 text-sm font-bold">
+          Stripe Hosted Capital
+          <div>
+            <Link
+              href="https://docs.stripe.com/api/account_links/create?rds=1#create_account_link-type"
+              className="text-xs"
+              target="_blank"
+            >
+              Account Links API Documentation
+            </Link>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <CapitalAccountLinkButton type="capital_financing_offer" />
+          <CapitalAccountLinkButton type="capital_financing_reporting" />
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Add buttons to the Manage Financing tab to create account links that point to the hosted dashboards. The account links open in new tabs, and are regenerated on refresh using nextjs' `redirect` method.


https://github.com/user-attachments/assets/5cbb65ff-16bf-4eb2-a60f-47f57e5f9e08

https://github.com/user-attachments/assets/004f55ce-82ec-47b2-a6f2-c843699d9029


