### PR TITLE
Replace raw fetch of Financing Endpoints with useQuery to avoid calling again during render

### DIFF
--- a/app/(dashboard)/finances/page.tsx
+++ b/app/(dashboard)/finances/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import {useRouter} from 'next/navigation';
 import {
   ConnectCapitalFinancingPromotion,
   ConnectFinancialAccount,
@@ -108,6 +109,7 @@ function FinancialAccountSection() {
 }
 
 function CapitalFinancingSection() {
+  const router = useRouter();
   // Only show the financing offer if there is one to show
   const [showFinancingOffer, setShowFinancingOffer] = React.useState(false);
   const handleFinancingOfferLoaded = ({productType}: FinancingProductType) => {
@@ -131,6 +133,9 @@ function CapitalFinancingSection() {
         <ConnectCapitalFinancingPromotion
           onEligibleFinancingOfferLoaded={handleFinancingOfferLoaded}
           layout={'banner'}
+          onApplicationSubmitted={() => {
+            router.push('/finances/financing');
+          }}
         />
       </EmbeddedComponentContainer>
     </Container>

--- a/app/components/CapitalFinancingPromotionSection.tsx
+++ b/app/components/CapitalFinancingPromotionSection.tsx
@@ -37,6 +37,9 @@ export function CapitalFinancingPromotionSection({
         <ConnectCapitalFinancingPromotion
           onEligibleFinancingOfferLoaded={handleFinancingOfferLoaded}
           layout={layout}
+          onApplicationSubmitted={() => {
+            window.location.reload();
+          }}
         />
       </EmbeddedComponentContainer>
     </Container>

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -26,16 +26,15 @@ import {TransitionFinancingButton} from './TransitionFinancingButton';
 import {Link} from '@/components/ui/link';
 import {ExternalLinkIcon} from '@radix-ui/react-icons';
 import {CapitalAccountLinkButton} from './CapitalAccountLinkButton';
+import {
+  useFinancingOfferFetchQuery,
+  useLineOfCreditSummaryFetchQuery,
+} from './financingQueryHooks';
 
 export default function ManageFinancing({classes}: {classes?: string}) {
-  const [loading, setLoading] = React.useState(true);
   const [offerState, setOfferState] = React.useState<OfferState | undefined>(
     undefined
   );
-
-  const [hasLineOfCreditFeature, setHasLineOfCreditFeature] =
-    React.useState(false);
-  const [hasLineOfCreditLine, setHasLineOfCreditLine] = React.useState(false);
 
   const form = useForm<TestmodeFinancingForm>({
     defaultValues: {
@@ -44,56 +43,35 @@ export default function ManageFinancing({classes}: {classes?: string}) {
     },
   });
 
-  React.useMemo(() => {
-    if (offerState === undefined) {
-      Promise.allSettled([
-        fetch('/api/capital/get_financing_offer', {
-          method: 'get',
-        }),
-        fetch('/api/capital/get_line_of_credit_summary', {
-          method: 'get',
-        }),
-      ])
-        .then(async ([offer, summary]) => {
-          if (summary.status === 'fulfilled') {
-            if (summary.value.ok) {
-              const summaryData = await summary.value.json();
-              setHasLineOfCreditFeature(true);
-              setHasLineOfCreditLine(summaryData.line_of_credit !== null);
-            } else {
-              const message = await summary.value.text();
-              if (
-                message.includes(
-                  'You do not have permission to pass this beta header'
-                )
-              ) {
-                setHasLineOfCreditFeature(false);
-                setHasLineOfCreditLine(false);
-              } else {
-                console.warn('An error occurred: ', message);
-              }
-            }
-          } else {
-            console.warn('An error occurred: ', summary.reason.message);
-          }
+  const {
+    isLoading: financingOfferLoading,
+    error: financingOfferError,
+    data: financingOffer,
+    refetch: refetchFinancingData,
+  } = useFinancingOfferFetchQuery();
 
-          if (offer.status === 'fulfilled') {
-            if (offer.value.ok) {
-              const status = (await offer.value.json()).offer?.status;
-              setOfferState(status || 'no_offer');
-            } else {
-              const message = await offer.value.text();
-              console.warn('An error occurred: ', message);
-            }
-          } else {
-            console.warn('An error occurred: ', offer.reason.message);
-          }
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+  const {
+    isLoading: lineOfCreditSummaryLoading,
+    error: lineOfCreditSummaryError,
+    data: lineOfCreditSummary,
+    refetch: refetchLineOfCreditSummary,
+  } = useLineOfCreditSummaryFetchQuery();
+
+  const queriesLoading = financingOfferLoading || lineOfCreditSummaryLoading;
+  const hasLineOfCreditFeature =
+    !lineOfCreditSummaryLoading && !lineOfCreditSummaryError;
+  const hasLineOfCreditLine =
+    !lineOfCreditSummaryLoading &&
+    !lineOfCreditSummaryError &&
+    lineOfCreditSummary?.line_of_credit !== null;
+
+  const offerStateRef = React.useRef<OfferState | undefined>(undefined);
+  if (!financingOfferLoading && !financingOfferError) {
+    offerStateRef.current = financingOffer?.offer?.status || 'no_offer';
+    if (offerStateRef.current != offerState) {
+      setOfferState(offerStateRef.current);
     }
-  }, [offerState]);
+  }
 
   const showCreateFinancingOfferForm = offerState && !hasLineOfCreditLine;
 
@@ -151,7 +129,7 @@ export default function ManageFinancing({classes}: {classes?: string}) {
                     </div>
                   }
                   form={form}
-                  loading={loading}
+                  loading={queriesLoading}
                   render={({field}) => {
                     return (
                       <Select
@@ -179,7 +157,7 @@ export default function ManageFinancing({classes}: {classes?: string}) {
                       >
                         <SelectTrigger
                           className="w-[120px] text-xs"
-                          disabled={loading}
+                          disabled={queriesLoading}
                         >
                           <SelectValue className="text-xs">
                             {enumValueToSentenceCase(field.value)}
@@ -211,7 +189,7 @@ export default function ManageFinancing({classes}: {classes?: string}) {
                   name="offerState"
                   label="Offer State"
                   form={form}
-                  loading={loading}
+                  loading={queriesLoading}
                   render={({field}) => {
                     return (
                       <Select
@@ -223,7 +201,7 @@ export default function ManageFinancing({classes}: {classes?: string}) {
                       >
                         <SelectTrigger
                           className="w-[120px] text-xs"
-                          disabled={loading}
+                          disabled={queriesLoading}
                         >
                           <SelectValue className="text-xs">
                             {enumValueToSentenceCase(field.value)}

--- a/app/components/testdata/Financing/TransitionFinancingButton.tsx
+++ b/app/components/testdata/Financing/TransitionFinancingButton.tsx
@@ -2,6 +2,7 @@ import {Button} from '@/components/ui/button';
 import {LoaderCircle} from 'lucide-react';
 import React from 'react';
 import {UseFormReturn} from 'react-hook-form';
+import {useMutation} from '@tanstack/react-query';
 
 export function TransitionFinancingButton({
   classes,
@@ -18,10 +19,8 @@ export function TransitionFinancingButton({
   fetchBody?: {};
   form?: UseFormReturn<any>;
 }) {
-  const [buttonLoading, setButtonLoading] = React.useState(false);
-  const onClick = async () => {
-    setButtonLoading(true);
-    try {
+  const {mutateAsync, isPending} = useMutation({
+    mutationFn: async () => {
       const res = await fetch(fetchUrl, {
         method,
         headers: {
@@ -29,15 +28,23 @@ export function TransitionFinancingButton({
         },
         body: JSON.stringify(fetchBody),
       });
-      setButtonLoading(false);
+      // Wait for 2 seconds to allow for side effects to complete
+      await new Promise((resolve) => setTimeout(resolve, 2000));
 
       if (res.ok) {
-        window.location.reload();
+        return res.json();
+      } else {
+        throw new Error('Failed to transition financing', {
+          cause: res.text(),
+        });
       }
-    } catch (e) {
-      console.log(`Error attempting to \`${label}\`: `, e);
-      setButtonLoading(false);
-    }
+    },
+    onSuccess: () => {
+      window.location.reload();
+    },
+  });
+  const onClick = async () => {
+    await mutateAsync();
   };
 
   return (
@@ -45,11 +52,11 @@ export function TransitionFinancingButton({
       className={`${classes || 'border'}`}
       variant="secondary"
       onClick={form ? form.handleSubmit(onClick) : onClick}
-      disabled={buttonLoading}
+      disabled={isPending}
       size="sm"
     >
       {label}
-      {buttonLoading && (
+      {isPending && (
         <LoaderCircle className="ml-2 animate-spin items-center" size={20} />
       )}
     </Button>

--- a/app/components/testdata/Financing/financingQueryHooks.tsx
+++ b/app/components/testdata/Financing/financingQueryHooks.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+export const useFinancingOfferFetchQuery = () => {
+  return useQuery({
+    queryKey: ['financing-data'],
+    queryFn: async () => {
+      const response = await fetch('/api/capital/get_financing_offer', {
+        method: 'get',
+      });
+
+      if (response.ok) {
+        return response.json();
+      } else {
+        throw new Error('Failed to fetch financing data', {
+          cause: response.text(),
+        });
+      }
+    },
+  });
+};
+
+export const useLineOfCreditSummaryFetchQuery = () => {
+  return useQuery({
+    queryKey: ['line-of-credit-summary'],
+    queryFn: async () => {
+      const response = await fetch('/api/capital/get_line_of_credit_summary', {
+        method: 'get',
+      });
+
+      if (response.ok) {
+        return response.json();
+      } else {
+        throw new Error('Failed to fetch line of credit summary', {
+          cause: response.text(),
+        });
+      }
+    },
+  });
+};


### PR DESCRIPTION
**Background**

Because the `fetch` calls are inline in the component and some are dependent on `offerState`, we would refetch the data unnecessarily during a re-render. Because the component render was dependent on the result of the queries, this would result form in the tools panel to "flicker" or act strangely during longer duration queries. 

We also did not handle application submission well prior to this and had an ask to refresh the page to just show the application tracker.

**AI Summary of changes**
- Introduced `useFinancingOfferFetchQuery` and `useLineOfCreditSummaryFetchQuery` hooks for fetching financing data.
- Updated `ManageFinancing` component to utilize the new hooks, improving data fetching logic and state management.
- Modified `CapitalFinancingSection` and `TransitionFinancingButton` components to handle application submission and loading states more effectively.
- Enhanced user experience by ensuring proper loading indicators and error handling during data fetching.


**Video**
This video shows some of the long running queries run more stably than before:

https://github.com/user-attachments/assets/c3eff620-ffda-49b5-b6b7-472f5b6ab9b0

