### PR TITLE
Consistently return company branding for an account on login / refresh

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -6,6 +6,27 @@ import {stripe} from '@/lib/stripe';
 import {resolveControllerParams} from './utils';
 import Stripe from 'stripe';
 
+type SalonDoc = {
+  _id: unknown;
+  email: string;
+  stripeAccountId?: string | null;
+  primaryColor?: string | null;
+  companyName?: string | null;
+  companyLogoUrl?: string | null;
+};
+
+/** Fields merged into JWT `token.user` and used by the session callback after credentials sign-in. */
+function userPayloadFromSalon(user: SalonDoc, emailOverride?: string) {
+  return {
+    id: String(user._id),
+    email: emailOverride ?? user.email,
+    stripeAccountId: user.stripeAccountId,
+    primaryColor: user.primaryColor,
+    companyName: user.companyName,
+    companyLogoUrl: user.companyLogoUrl,
+  };
+}
+
 export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
@@ -91,11 +112,7 @@ export const authOptions: AuthOptions = {
           return null;
         }
 
-        return {
-          id: user._id,
-          email: credentials?.email,
-          stripeAccountId: user.stripeAccountId,
-        };
+        return userPayloadFromSalon(user, credentials?.email);
       },
     }),
     CredentialsProvider({
@@ -130,11 +147,7 @@ export const authOptions: AuthOptions = {
           return null;
         }
 
-        return {
-          id: user._id,
-          email: user.email,
-          stripeAccountId: user.stripeAccountId,
-        };
+        return userPayloadFromSalon(user);
       },
     }),
     CredentialsProvider({
@@ -187,11 +200,7 @@ export const authOptions: AuthOptions = {
           return null;
         }
 
-        return {
-          id: user!._id,
-          email: user!.email,
-          stripeAccountId: user!.stripeAccountId,
-        };
+        return userPayloadFromSalon(user!);
       },
     }),
     CredentialsProvider({


### PR DESCRIPTION
Currently on furever, the branding you select for an account is persisted in the database but is not retrieved during logging in (and only partially retrieves it on refreshing the page).

This PR adds a consistent response on auth that includes all branding fields available in the database.

<details>
  <summary>[Video] Issue repro</summary>
  
https://github.com/user-attachments/assets/828636f6-14b4-4caf-b6bf-1a3776e0c8f3

</details>

<details>
  <summary>[Video] Fix</summary>
  
https://github.com/user-attachments/assets/ba389cad-0f4a-43cd-8812-2b9dcb416f26

</details>



