### PR TITLE
Support Line of Credit applications by using Line of Credit API preview header (with fallback)

### DIFF
--- a/app/api/capital/api_helpers.tsx
+++ b/app/api/capital/api_helpers.tsx
@@ -1,0 +1,39 @@
+import {stripe} from '@/lib/stripe';
+
+export const getFinancingOffersList = async ({
+  connected_account,
+  limit = undefined,
+}: {
+  connected_account: string;
+  limit?: number | undefined;
+}) => {
+  const overrideApiVersion =
+    '2026-03-25.dahlia; capital_line_of_credit_preview=v1';
+
+  return await stripe.capital.financingOffers
+    .list(
+      {
+        connected_account: connected_account,
+        limit: limit,
+      },
+      {
+        apiVersion: overrideApiVersion,
+      }
+    )
+    .then(
+      (response) => {
+        return response;
+      },
+      // fallback to default API version if the override API version is not supported by the platform
+      async () => {
+        console.log(
+          'v1/capital/financing_offers: Unable to use line of credit preview API version. Falling back to default API version.'
+        );
+        return await stripe.capital.financingOffers.list({
+          connected_account: connected_account,
+          limit: 1,
+        });
+      }
+    );
+  // Let caller handle final error
+};

--- a/app/api/capital/approve_test_financing/route.ts
+++ b/app/api/capital/approve_test_financing/route.ts
@@ -1,6 +1,7 @@
 import {getServerSession} from 'next-auth/next';
 import {authOptions} from '@/lib/auth';
 import {stripe} from '@/lib/stripe';
+import {getFinancingOffersList} from '../api_helpers';
 
 export async function POST() {
   try {
@@ -14,7 +15,7 @@ export async function POST() {
     const connected_account = session.user.stripeAccountId;
 
     const offer = (
-      await stripe.capital.financingOffers.list({
+      await getFinancingOffersList({
         connected_account: connected_account,
         limit: 1,
       })

--- a/app/api/capital/expire_test_financing/route.ts
+++ b/app/api/capital/expire_test_financing/route.ts
@@ -1,6 +1,7 @@
 import {getServerSession} from 'next-auth/next';
 import {authOptions} from '@/lib/auth';
 import {stripe} from '@/lib/stripe';
+import {getFinancingOffersList} from '../api_helpers';
 
 export async function POST() {
   try {
@@ -13,7 +14,7 @@ export async function POST() {
 
     const connected_account = session.user.stripeAccountId;
     const offer = (
-      await stripe.capital.financingOffers.list({
+      await getFinancingOffersList({
         connected_account: connected_account,
         limit: 1,
       })

--- a/app/api/capital/fully_repay_test_financing/route.ts
+++ b/app/api/capital/fully_repay_test_financing/route.ts
@@ -1,6 +1,7 @@
 import {getServerSession} from 'next-auth/next';
 import {authOptions} from '@/lib/auth';
 import {stripe} from '@/lib/stripe';
+import {getFinancingOffersList} from '../api_helpers';
 
 export async function POST() {
   try {
@@ -15,7 +16,7 @@ export async function POST() {
     const connected_account = session.user.stripeAccountId;
 
     const offer = (
-      await stripe.capital.financingOffers.list({
+      await getFinancingOffersList({
         connected_account: connected_account,
         limit: 1,
       })

--- a/app/api/capital/get_financing_offer/route.ts
+++ b/app/api/capital/get_financing_offer/route.ts
@@ -14,12 +14,46 @@ export async function GET() {
 
     const connected_account = session.user.stripeAccountId;
 
-    const offer = (
-      await stripe.capital.financingOffers.list({
-        connected_account: connected_account,
-        limit: 1,
-      })
-    ).data.at(0);
+    const overrideApiVersion =
+      '2026-03-25.dahlia; capital_line_of_credit_preview=v1';
+
+    const offer = await stripe.capital.financingOffers
+      .list(
+        {
+          connected_account: connected_account,
+          limit: 1,
+        },
+        {
+          apiVersion: overrideApiVersion,
+        }
+      )
+      .then(
+        (response) => {
+          return response.data.at(0);
+        },
+        // fallback to default API version if the override API version is not supported by the platform
+        async () => {
+          console.log(
+            'v1/capital/financing_offers: Unable to use line of credit preview API version. Falling back to default API version.'
+          );
+          return (
+            await stripe.capital.financingOffers.list({
+              connected_account: connected_account,
+              limit: 1,
+            })
+          ).data.at(0);
+        }
+      )
+      .catch((reason) => {
+        console.error(
+          'An error occurred when calling the Stripe API to list financing offers',
+          reason
+        );
+        return new Response(JSON.stringify(reason), {
+          status: 500,
+          headers: {'Content-Type': 'application/json'},
+        });
+      });
 
     return new Response(
       JSON.stringify({

--- a/app/api/capital/get_financing_offer/route.ts
+++ b/app/api/capital/get_financing_offer/route.ts
@@ -1,6 +1,7 @@
 import {getServerSession} from 'next-auth/next';
 import {authOptions} from '@/lib/auth';
 import {stripe} from '@/lib/stripe';
+import {getFinancingOffersList} from '../api_helpers';
 
 export async function GET() {
   try {
@@ -17,42 +18,15 @@ export async function GET() {
     const overrideApiVersion =
       '2026-03-25.dahlia; capital_line_of_credit_preview=v1';
 
-    const offer = await stripe.capital.financingOffers
-      .list(
-        {
-          connected_account: connected_account,
-          limit: 1,
-        },
-        {
-          apiVersion: overrideApiVersion,
-        }
-      )
-      .then(
-        (response) => {
-          return response.data.at(0);
-        },
-        // fallback to default API version if the override API version is not supported by the platform
-        async () => {
-          console.log(
-            'v1/capital/financing_offers: Unable to use line of credit preview API version. Falling back to default API version.'
-          );
-          return (
-            await stripe.capital.financingOffers.list({
-              connected_account: connected_account,
-              limit: 1,
-            })
-          ).data.at(0);
-        }
-      )
+    const offer = await getFinancingOffersList({connected_account, limit: 1})
+      .then((response) => {
+        return response.data.at(0);
+      })
       .catch((reason) => {
-        console.error(
+        throw new Error(
           'An error occurred when calling the Stripe API to list financing offers',
           reason
         );
-        return new Response(JSON.stringify(reason), {
-          status: 500,
-          headers: {'Content-Type': 'application/json'},
-        });
       });
 
     return new Response(

--- a/app/api/capital/reject_test_financing/route.ts
+++ b/app/api/capital/reject_test_financing/route.ts
@@ -1,6 +1,7 @@
 import {getServerSession} from 'next-auth/next';
 import {authOptions} from '@/lib/auth';
 import {stripe} from '@/lib/stripe';
+import {getFinancingOffersList} from '../api_helpers';
 
 export async function POST() {
   try {
@@ -15,7 +16,7 @@ export async function POST() {
     const connected_account = session.user.stripeAccountId;
 
     const offer = (
-      await stripe.capital.financingOffers.list({
+      await getFinancingOffersList({
         connected_account: connected_account,
         limit: 1,
       })

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -73,7 +73,6 @@ export default function ManageFinancing({classes}: {classes?: string}) {
     }
   }
 
-  const showCreateFinancingOfferForm = offerState && !hasLineOfCreditLine;
 
   const formFinancingOfferType = form.watch('financingOfferType');
   const formOfferState = form.watch('offerState');
@@ -98,6 +97,10 @@ export default function ManageFinancing({classes}: {classes?: string}) {
 
   const formType = offerStateToFormType[offerState || 'no_offer'];
   const createUrl = PRODUCT_TYPE_CREATE_URLS[formFinancingOfferType];
+
+    const showCreateFinancingOfferForm =
+      offerState && (formType === 'approve_reject' || !hasLineOfCreditLine);
+
 
   const supportedProductTypes = FINANCING_OFFER_PRODUCT_TYPES_ARRAY;
 

--- a/app/components/testdata/Financing/ManageFinancing.tsx
+++ b/app/components/testdata/Financing/ManageFinancing.tsx
@@ -73,7 +73,6 @@ export default function ManageFinancing({classes}: {classes?: string}) {
     }
   }
 
-
   const formFinancingOfferType = form.watch('financingOfferType');
   const formOfferState = form.watch('offerState');
 
@@ -98,9 +97,8 @@ export default function ManageFinancing({classes}: {classes?: string}) {
   const formType = offerStateToFormType[offerState || 'no_offer'];
   const createUrl = PRODUCT_TYPE_CREATE_URLS[formFinancingOfferType];
 
-    const showCreateFinancingOfferForm =
-      offerState && (formType === 'approve_reject' || !hasLineOfCreditLine);
-
+  const showCreateFinancingOfferForm =
+    offerState && (formType === 'approve_reject' || !hasLineOfCreditLine);
 
   const supportedProductTypes = FINANCING_OFFER_PRODUCT_TYPES_ARRAY;
 


### PR DESCRIPTION
Because Line of Credit offers are hidden by a preview header in the LIST endpoint, we need to use the preview header in the API call to support Line of Credit offers that are applied for. This lets the right approve/reject buttons helpers. 

Creating a line of credit offer from the Tools Panel is already guarded by the preview header. 

This PR also allows us to show the approve_reject application helpers even when there is a line of credit active. This enables us to approve/reject subsequent draws from a line.

<details>
  <summary>Screenshots</summary>
  
<img width="1036" height="158" alt="CleanShot 2026-04-24 at 14 16 01@2x" src="https://github.com/user-attachments/assets/bcaf9d47-01e7-4bc9-9154-5ec009f09b19" />


<img width="2252" height="854" alt="CleanShot 2026-04-24 at 14 16 52@2x" src="https://github.com/user-attachments/assets/f8789be4-09b1-407d-a186-a28c53ef11fe" />
</details>




<details>
  <summary>Video: Without the gate</summary>
 
https://github.com/user-attachments/assets/6a1cde52-6775-4f64-b2d9-614785eab21a


</details>



<details>
  <summary>Video: Without gate</summary>
 

https://github.com/user-attachments/assets/d57d677e-1deb-425a-8ecc-835da5997476

</details>
