### PR TITLE
ci: add explicit permissions to build workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ env:
   SECRET: S3cr3t
   MONGO_URI: 'mongodb://localhost/furever'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restricts the GITHUB_TOKEN to `contents: read` on the build workflow. The workflow checks out code, installs dependencies, and runs build validation. None of these steps need write access.

Applying least-privilege scoping to Actions tokens is a security best practice that limits exposure if any dependency in the pipeline is compromised.