### PR TITLE
Add product tax code selector embedded component

### DIFF
--- a/app/(dashboard)/settings/tax/page.tsx
+++ b/app/(dashboard)/settings/tax/page.tsx
@@ -7,6 +7,7 @@ import {
   ConnectTaxRegistrations,
   ConnectTaxThresholdMonitoring,
   ConnectExportTaxTransactions,
+  ConnectProductTaxCodeSelector,
 } from '@stripe/react-connect-js';
 import {arePreviewComponentsEnabled} from '../../utils/arePreviewComponentsEnabled';
 
@@ -34,6 +35,26 @@ export default function Tax() {
       </Container>
       {arePreviewComponentsEnabled && (
         <>
+          <Container>
+            <h1 className="text-xl font-semibold">Product tax code</h1>
+            <p className="text-subdued">
+              Assign a tax code to your &ldquo;Wash and groom&rdquo; service so
+              Stripe Tax calculates the correct tax on each booking.
+            </p>
+            <EmbeddedComponentContainer
+              componentName="ProductTaxCodeSelector"
+              isPreviewComponent
+            >
+              <ConnectProductTaxCodeSelector
+                initialTaxCode="txcd_20030003"
+                onTaxCodeSelect={(id) => {
+                  // Persist the selected tax code against the "Wash and groom"
+                  // product/service in your catalog.
+                  console.log('Selected tax code for Wash and groom:', id);
+                }}
+              />
+            </EmbeddedComponentContainer>
+          </Container>
           <Container>
             <h1 className="text-xl font-semibold">Threshold Monitoring</h1>
             <p className="text-subdued">

--- a/app/api/account_session/route.ts
+++ b/app/api/account_session/route.ts
@@ -130,6 +130,9 @@ export async function POST(req: NextRequest) {
           // Preview components - only enabled if the environment variable is set
           ...(hasPreviewComponents
             ? {
+                product_tax_code_selector: {
+                  enabled: true,
+                },
                 payment_method_settings: {enabled: true},
                 capital_financing_promotion: {
                   enabled: true,

--- a/app/components/EmbeddedComponentContainer.tsx
+++ b/app/components/EmbeddedComponentContainer.tsx
@@ -59,6 +59,8 @@ const EmbeddedComponentContainer = ({
         'https://docs.stripe.com/connect/supported-embedded-components/tax-threshold-monitoring',
       ExportTaxTransactions:
         'https://docs.stripe.com/connect/supported-embedded-components/export-tax-transactions',
+      ProductTaxCodeSelector:
+        'https://docs.stripe.com/connect/supported-embedded-components/product-tax-code-selector',
     };
 
     if (!enableBorder) {


### PR DESCRIPTION
Add Product Tax Code Selector embedded component to showcase the component (Preview Component).

Already added the account (`acct_1KgGJqGxJ4qxTuYt`) to the gate enabling this component.

Tested locally:
<img width="893" height="130" alt="image" src="https://github.com/user-attachments/assets/43f4412c-c261-4bb4-94bd-163425ea1d7c" />
