### PR TITLE
Fix clearing the brand icon

### DIFF
--- a/app/components/BrandSettingsModal.tsx
+++ b/app/components/BrandSettingsModal.tsx
@@ -176,7 +176,7 @@ const BrandSettingsModal = () => {
         await update({
           user: {
             ...session?.user,
-            companyLogoUrl: undefined,
+            companyLogoUrl: null,
           },
         });
       } else {
@@ -236,7 +236,7 @@ const BrandSettingsModal = () => {
         user: {
           ...session?.user,
           companyName: 'Furever',
-          companyLogoUrl: undefined,
+          companyLogoUrl: null,
           primaryColor: defaultPrimaryColor,
         },
       });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -65,7 +65,10 @@ export const authOptions: AuthOptions = {
         if (session?.user.companyName) {
           token.user.companyName = session.user.companyName;
         }
-        if (session?.user.companyLogoUrl) {
+        if (
+          session?.user.companyLogoUrl ||
+          session?.user.companyLogoUrl === null
+        ) {
           token.user.companyLogoUrl = session.user.companyLogoUrl;
         }
         if (session?.user.setup) {


### PR DESCRIPTION
Today if you try to clear the brand icon either by selecting "X" or clicking "reset, it unfortunately does not work:

<img width="644" height="582" alt="image" src="https://github.com/user-attachments/assets/6aee469f-ceb2-403d-a5eb-f9560f90c6fb" />

This is because the update logic on the `session` prevents falsy values from making it through. With this PR, `null` values can make it through, making `clear` and `reset` work again.

<img width="577" height="419" alt="image" src="https://github.com/user-attachments/assets/29e95f22-0460-4eb8-ae14-2ed249d0d994" />
