### PR TITLE
Allow Express account fee collection + bump preview version

### DIFF
--- a/app/(auth)/business/form.tsx
+++ b/app/(auth)/business/form.tsx
@@ -296,13 +296,14 @@ export default function BusinessDetailsForm({email}: {email: string}) {
     ) {
       form.setValue('paymentLosses', 'stripe');
       form.setValue('feePayer', 'account');
-    } else if (
-      form.getValues('stripeDashboardType') === 'express' &&
-      (form.getValues('paymentLosses') !== 'application' ||
-        form.getValues('feePayer') !== 'application')
-    ) {
-      form.setValue('paymentLosses', 'application');
-      form.setValue('feePayer', 'application');
+    } else if (form.getValues('stripeDashboardType') === 'express') {
+      // Only invalid combo for express: application losses + account fee payer
+      if (
+        form.getValues('paymentLosses') === 'application' &&
+        form.getValues('feePayer') === 'account'
+      ) {
+        form.setValue('feePayer', 'application');
+      }
     } else {
       if (
         form.getValues('paymentLosses') === 'application' &&
@@ -334,11 +335,10 @@ export default function BusinessDetailsForm({email}: {email: string}) {
 
   const formValues = form.getValues();
   const validPaymentLosses = paymentLosses.filter((option) => {
-    if (option === 'application') {
-      return formValues.stripeDashboardType !== 'full';
-    } else if (option === 'stripe') {
-      return formValues.stripeDashboardType !== 'express';
-    }
+    // Full dashboard accounts require Stripe to own negative balance liability.
+    return (
+      option !== 'application' || formValues.stripeDashboardType !== 'full'
+    );
   });
   const validFeePayers = feePayers.filter((option) => {
     if (option === 'application') {
@@ -346,7 +346,8 @@ export default function BusinessDetailsForm({email}: {email: string}) {
     } else if (option === 'account') {
       return (
         formValues.stripeDashboardType === 'full' ||
-        (formValues.stripeDashboardType === 'none' &&
+        ((formValues.stripeDashboardType === 'none' ||
+          formValues.stripeDashboardType === 'express') &&
           formValues.paymentLosses === 'stripe')
       );
     }

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 
-export const latestApiVersion = '2026-06-03.preview';
+export const latestApiVersion = '2026-06-24.preview';
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
   apiVersion: latestApiVersion,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.51.1",
     "sharp": "^0.33.4",
-    "stripe": "^22.3.0-alpha.2",
+    "stripe": "22.4.0-beta.1",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
     "yarn": "^1.22.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4608,10 +4608,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@^22.3.0-alpha.2:
-  version "22.3.0-alpha.2"
-  resolved "https://registry.npmjs.org/stripe/-/stripe-22.3.0-alpha.2.tgz"
-  integrity sha512-uzH5gAOvs9CK7WXhzl9mL6wJdMKYm2hH5WeIK+B1UVRwne3joT9SfgehspWe4iDBylHx3bw0lcAILxFHq7qy7Q==
+stripe@22.4.0-beta.1:
+  version "22.4.0-beta.1"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-22.4.0-beta.1.tgz#a85e0c4ef4a9550fdf65c59cb9df2d6bb7c01813"
+  integrity sha512-tuV9BlNQhEpxscZpADb8VavhM5lONFk3qZ5CbbnVe5H8VISIzhUbKTGX7qeZAmWXVeoiavHizEOhWyKnyGgZ+g==
 
 styled-jsx@5.1.1:
   version "5.1.1"


### PR DESCRIPTION
 ## Summary

  Expose the newly supported Express Dashboard account configuration enabled by `2026-06-24.preview`:

  - Express Dashboard
  - Stripe owns negative balance losses
  - Stripe collects fees from connected accounts

  ## Changes

  - Bump Stripe preview API version from `2026-06-03.preview` to `2026-06-24.preview`.
  - Allow `stripe` negative balance liability for Express Dashboard accounts.
  - Allow `account` fee payer when dashboard type is Express and losses are owned by Stripe.
  - Keep the Express auto-reset behavior only for the invalid combo: application-owned losses with account-paid fees.
  - Refactor the payment-loss filter with a comment clarifying that Full Dashboard accounts require Stripe-owned loss liability.

  ## Verification

Tested locally confirmed SES account was successfully created + went through onboarding + verified furever ux after


<img width="980" height="736" alt="Screenshot 2026-07-01 at 10 56 33 AM" src="https://github.com/user-attachments/assets/3e53d02d-87f8-435c-b16b-a660f399aed8" />

<img width="1216" height="864" alt="Screenshot 2026-07-01 at 11 01 21 AM" src="https://github.com/user-attachments/assets/08071286-020f-46e3-9198-b5f35a240fed" />
