### PR TITLE
Migrate example connect backend to Furever

### DIFF
--- a/app/account_session/route.ts
+++ b/app/account_session/route.ts
@@ -1,0 +1,37 @@
+import {type NextRequest, NextResponse} from 'next/server';
+import {createMobileConnectAccountSession} from '@/lib/mobileConnectDemo';
+
+export async function POST(request: NextRequest) {
+  const account =
+    request.headers.get('account') || process.env.DEFAULT_CONNECTED_ACCOUNT;
+
+  if (!account) {
+    return NextResponse.json(
+      {error: 'An account header or DEFAULT_CONNECTED_ACCOUNT is required.'},
+      {status: 400}
+    );
+  }
+
+  if (!account.startsWith('acct_')) {
+    return NextResponse.json(
+      {error: 'The account must be a valid Stripe account ID.'},
+      {status: 400}
+    );
+  }
+
+  try {
+    const accountSession = await createMobileConnectAccountSession(account);
+
+    return NextResponse.json({client_secret: accountSession.client_secret});
+  } catch (error) {
+    console.error(
+      'An error occurred when calling the Stripe API to create a mobile Connect account session',
+      error
+    );
+
+    return NextResponse.json(
+      {error: error instanceof Error ? error.message : 'Unknown error'},
+      {status: 500}
+    );
+  }
+}

--- a/app/account_session/route.ts
+++ b/app/account_session/route.ts
@@ -2,15 +2,7 @@ import {type NextRequest, NextResponse} from 'next/server';
 import {createMobileConnectAccountSession} from '@/lib/mobileConnectDemo';
 
 export async function POST(request: NextRequest) {
-  const account =
-    request.headers.get('account') || process.env.DEFAULT_CONNECTED_ACCOUNT;
-
-  if (!account) {
-    return NextResponse.json(
-      {error: 'An account header or DEFAULT_CONNECTED_ACCOUNT is required.'},
-      {status: 400}
-    );
-  }
+  const account = request.headers.get('account') || 'acct_1N9FIXQ26HdRlxHg';
 
   if (!account.startsWith('acct_')) {
     return NextResponse.json(

--- a/app/app_info/route.ts
+++ b/app/app_info/route.ts
@@ -1,0 +1,98 @@
+import {NextResponse} from 'next/server';
+import {assertTestMode} from '@/lib/mobileConnectDemo';
+
+export const dynamic = 'force-dynamic';
+
+const availableMerchants = [
+  {display_name: 'Default (Custom)', merchant_id: 'acct_1N9FIXQ26HdRlxHg'},
+  {
+    display_name: 'Onboarding (Custom W)',
+    merchant_id: 'acct_1SxE0tLRuQcyS3ni',
+  },
+  {
+    display_name: 'Onboarding (Custom X)',
+    merchant_id: 'acct_1SxE2gLI4wv1VRRP',
+  },
+  {
+    display_name: 'Onboarding (Custom Y)',
+    merchant_id: 'acct_1SxE3QPzl24uL4qM',
+  },
+  {
+    display_name: 'Onboarding (Custom Z)',
+    merchant_id: 'acct_1SxE3yQ13bBuNBv2',
+  },
+  {display_name: 'Onboarding (UA7)', merchant_id: 'acct_1SxE4iLdTJoSTdxZ'},
+  {
+    display_name: 'Onboarding (Standard)',
+    merchant_id: 'acct_1SxE5BPyfn1Wvsjr',
+  },
+  {
+    display_name: 'Onboarding (Standard 2)',
+    merchant_id: 'acct_1SxEHnLGCHvMfTBi',
+  },
+  {
+    display_name: 'Onboarding (Express)',
+    merchant_id: 'acct_1SxE5jLXrDlNQ5Hc',
+  },
+  {display_name: 'Onboarding (PNP)', merchant_id: 'acct_1SxE6XL44pZEVwR1'},
+  {
+    display_name: 'Onboarding (Germany)',
+    merchant_id: 'acct_1SxEIiLgSKBc3GqT',
+  },
+  {
+    display_name: 'Onboarding (Japan)',
+    merchant_id: 'acct_1SwnnHQ11zy1CKJV',
+  },
+  {
+    display_name: 'Onboarding (Canada)',
+    merchant_id: 'acct_1SxEJoLgLddATk6N',
+  },
+  {
+    display_name: 'Payments/Payouts (Express, US)',
+    merchant_id: 'acct_1Sd26mLZ6KmkRAhV',
+  },
+  {
+    display_name: 'Payments/Payouts (Custom, DE)',
+    merchant_id: 'acct_1SnPRFLRXJX4cV3R',
+  },
+  {
+    display_name: 'Payments/Payouts (Express, JP)',
+    merchant_id: 'acct_1SnPTdLyKK8AwfKj',
+  },
+  {
+    display_name: 'Payments/Payouts (Express w/USDC)',
+    merchant_id: 'acct_1SnPYTLRfeFR501j',
+  },
+  {
+    display_name: 'Payments/Payouts (UA7 account)',
+    merchant_id: 'acct_1SnPe2L0DT036FLh',
+  },
+];
+
+export async function GET() {
+  try {
+    assertTestMode();
+
+    const publishableKey =
+      process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY ||
+      process.env.STRIPE_PUBLISHABLE_KEY;
+
+    if (!publishableKey?.startsWith('pk_test_')) {
+      throw new Error(
+        'The mobile Connect demo endpoints require a test-mode Stripe publishable key.'
+      );
+    }
+
+    return NextResponse.json({
+      publishable_key: publishableKey,
+      available_merchants: availableMerchants,
+    });
+  } catch (error) {
+    console.error('Unable to load mobile Connect demo app info', error);
+
+    return NextResponse.json(
+      {error: error instanceof Error ? error.message : 'Unknown error'},
+      {status: 500}
+    );
+  }
+}

--- a/app/app_info/route.ts
+++ b/app/app_info/route.ts
@@ -73,9 +73,7 @@ export async function GET() {
   try {
     assertTestMode();
 
-    const publishableKey =
-      process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY ||
-      process.env.STRIPE_PUBLISHABLE_KEY;
+    const publishableKey = process.env.STRIPE_PUBLISHABLE_KEY;
 
     if (!publishableKey?.startsWith('pk_test_')) {
       throw new Error(

--- a/lib/mobileConnectDemo.ts
+++ b/lib/mobileConnectDemo.ts
@@ -1,0 +1,101 @@
+import Stripe from 'stripe';
+import {latestApiVersion, stripe} from '@/lib/stripe';
+
+type MobileAccountSessionComponents =
+  Stripe.AccountSessionCreateParams.Components & {
+    check_scanning: {enabled: boolean};
+  };
+
+const accountSessionComponents = (
+  disableStripeUserAuthentication: boolean
+): MobileAccountSessionComponents => ({
+  account_onboarding: {
+    enabled: true,
+    features: {
+      external_account_collection: true,
+      disable_stripe_user_authentication: disableStripeUserAuthentication,
+    },
+  },
+  payouts: {
+    enabled: true,
+    features: {
+      instant_payouts: true,
+      standard_payouts: true,
+      edit_payout_schedule: true,
+      external_account_collection: true,
+      disable_stripe_user_authentication: disableStripeUserAuthentication,
+    },
+  },
+  notification_banner: {
+    enabled: true,
+    features: {
+      external_account_collection: true,
+      disable_stripe_user_authentication: disableStripeUserAuthentication,
+    },
+  },
+  payments: {
+    enabled: true,
+  },
+  check_scanning: {
+    enabled: true,
+  },
+});
+
+const accountSessionRequestOptions = {
+  apiVersion: `${latestApiVersion}; embedded_connect_beta=v2`,
+} as const;
+
+export function assertTestMode() {
+  if (!/^(sk|rk)_test_/.test(process.env.STRIPE_SECRET_KEY || '')) {
+    throw new Error(
+      'The mobile Connect demo endpoints require a test-mode Stripe secret key.'
+    );
+  }
+}
+
+function canRetryWithStripeAuthentication(error: unknown) {
+  if (!(error instanceof Stripe.errors.StripeInvalidRequestError)) {
+    return false;
+  }
+
+  const parameter = error.param || '';
+  const message = error.message.toLowerCase();
+
+  return (
+    parameter.includes('disable_stripe_user_authentication') ||
+    message.includes('disable_stripe_user_authentication') ||
+    (message.includes('stripe user authentication') &&
+      (message.includes('account type') ||
+        message.includes('requirement_collection')))
+  );
+}
+
+export async function createMobileConnectAccountSession(account: string) {
+  assertTestMode();
+
+  try {
+    return await stripe.accountSessions.create(
+      {
+        account,
+        components: accountSessionComponents(true),
+      },
+      accountSessionRequestOptions
+    );
+  } catch (error) {
+    if (!canRetryWithStripeAuthentication(error)) {
+      throw error;
+    }
+
+    console.warn(
+      `Stripe user authentication cannot be disabled for ${account}; retrying with authentication enabled.`
+    );
+
+    return stripe.accountSessions.create(
+      {
+        account,
+        components: accountSessionComponents(false),
+      },
+      accountSessionRequestOptions
+    );
+  }
+}

--- a/types/environment.d.ts
+++ b/types/environment.d.ts
@@ -3,8 +3,6 @@ declare global {
     interface ProcessEnv {
       STRIPE_SECRET_KEY: string;
       STRIPE_PUBLISHABLE_KEY: string;
-      NEXT_PUBLIC_STRIPE_PUBLIC_KEY: string;
-      DEFAULT_CONNECTED_ACCOUNT?: string;
       APP_NAME: string;
       PORT: number;
       SECRET: string;

--- a/types/environment.d.ts
+++ b/types/environment.d.ts
@@ -3,6 +3,8 @@ declare global {
     interface ProcessEnv {
       STRIPE_SECRET_KEY: string;
       STRIPE_PUBLISHABLE_KEY: string;
+      NEXT_PUBLIC_STRIPE_PUBLIC_KEY: string;
+      DEFAULT_CONNECTED_ACCOUNT?: string;
       APP_NAME: string;
       PORT: number;
       SECRET: string;


### PR DESCRIPTION
Migrates the example BE server we use in the Connect example app in `stripe-ios`, `stripe-android`, and `stripe-react-native` to here for ease of us. 